### PR TITLE
Fix incorrect string concatenation i honeypot

### DIFF
--- a/library/Comment/HoneyPot.php
+++ b/library/Comment/HoneyPot.php
@@ -15,7 +15,7 @@ class HoneyPot
         }
 
         //Verification values
-        $this->field_content = substr(md5(NONCE_SALT+NONCE_KEY), 5, 15);
+        $this->field_content = substr(md5(NONCE_SALT . NONCE_KEY), 5, 15);
         $this->field_name = substr(md5(AUTH_KEY), 5, 15);
 
         //Print frontend fields


### PR DESCRIPTION
This is completely untested but I think it just fixes a typo. It will however change the value of `$this->field_content` since `NONCE_SALT+NONCE_KEY` is 0. I think that you want to concatenate those strings so that is what I'm doing instead.

It also fixes an error in PHP 7.1 since 7.1 complains when you use `.` with strings.

