### PR TITLE
Fix performance regression in menu if no current page

### DIFF
--- a/library/Helper/NavigationTree.php
+++ b/library/Helper/NavigationTree.php
@@ -77,8 +77,10 @@ class NavigationTree
         if ($this->args['include_top_level']) {
             $this->walk($this->topLevelPages);
         } else {
-            $page = isset($this->ancestors[0]) ? array($this->ancestors[0]) : array($this->currentPage);
-            $this->walk($page);
+            $page = isset($this->ancestors[0]) ? $this->ancestors[0] : $this->currentPage;
+            if ($page) {
+                $this->walk(array($page));
+            }
         }
     }
 


### PR DESCRIPTION
There is a huge performance regression on my local site when performing a search with no results. From 10s to 1.5s.

I'm not sure the if clause introduced here is the best place to deal with it, but works for me...

The underlying issue is that getCurrentPage(),  returns Null if there are no results, but the first result if there are results (`get_queried_object()`). See https://github.com/helsingborg-stad/Municipio/blob/master/library/Helper/NavigationTree.php#L144

When walk() then gets an array with Null as the only item it goes out of control it seems.

