### PR TITLE
Add theme option to disable mobile menu

### DIFF
--- a/acf-exports/acf-theme-options-mobile-navigation.json
+++ b/acf-exports/acf-theme-options-mobile-navigation.json
@@ -1,0 +1,42 @@
+    {
+        "key": "group_5885cbc79fc34",
+        "title": "Mobile navigation",
+        "fields": [
+            {
+                "default_value": 1,
+                "message": "Enable separate mobile navigation",
+                "ui": 0,
+                "ui_on_text": "",
+                "ui_off_text": "",
+                "key": "field_5885cbc7b0065",
+                "label": "Activate",
+                "name": "nav_mobile_enable",
+                "type": "true_false",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                }
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "options_page",
+                    "operator": "==",
+                    "value": "acf-options-navigation"
+                }
+            ]
+        ],
+        "menu_order": 2,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": 1,
+        "description": ""
+    }

--- a/library/Helper/Navigation.php
+++ b/library/Helper/Navigation.php
@@ -50,6 +50,9 @@ class Navigation
      */
     public function mobileMenu()
     {
+        if (get_field('nav_mobile_enable', 'option') === false) {
+            return '';
+        }
         if (get_field('nav_primary_enable', 'option') === false && get_field('nav_sub_enable', 'option') === false) {
             return '';
         }


### PR DESCRIPTION
We plan to not use the mobile menu at all. This adds a setting to disable it. This is mainly for performance reasons since even if we don't output it in our theme it's still being created. And the menu code is as you know quite heavy.

Since it's enabled by default and we do a strict check (if the option is `null` it will be rendered) it means it's backward compatible.