### PR TITLE
Fix sort by meta field on archive pages

### DIFF
--- a/library/Content/PostFilters.php
+++ b/library/Content/PostFilters.php
@@ -240,22 +240,7 @@ class PostFilters
 
         // Continue if meta query
         $query->set('meta_key', $orderby);
-        $query->set(
-            'meta_query',
-            array(
-                'relation' => 'OR',
-                array(
-                    'key' => $orderby,
-                    'compare' => 'EXISTS'
-                ),
-                array(
-                    'key' => $orderby,
-                    'compare' => 'NOT EXISTS'
-                )
-            )
-        );
-
-        $query->set('orderby', 'meta_key');
+        $query->set('orderby', 'meta_value');
 
         return $query;
     }


### PR DESCRIPTION
This follows the same approach as in https://github.com/helsingborg-stad/Modularity/pull/16.

Again, I'm not sure if meta_query that is removed in this commit did something else than sort.