### PR TITLE
Use ACF PRO

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "composer/installers": "^1.0",
         "philo/laravel-blade": "^3.1",
         "symfony/debug": "^3.0",
-        "wpackagist-plugin/advanced-custom-fields": "^4.4.7",
         "helsingborg-stad/acf-export-manager": ">=1.0.0",
         "aristath/kirki": "^3.0"
     },

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,9 @@ $ npm install
 $ composer install
 ```
 
+## Dependencies
+Municipio requires [ACF PRO](https://www.advancedcustomfields.com/pro/).
+
 ## Coding standards
 For PHP, use PSR-2 and PSR-4 where applicable.
 


### PR DESCRIPTION
- Remove composer dependency on ACF Free.
- Document the need for ACF PRO.