### PR TITLE
Document dependency on ACF PRO

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,9 @@ $ npm install
 $ composer install
 ```
 
+## Dependencies
+Municipio requires [ACF PRO](https://www.advancedcustomfields.com/pro/).
+
 ## Coding standards
 For PHP, use PSR-2 and PSR-4 where applicable.
 


### PR DESCRIPTION
Adds a very short note regarding the dependency on ACF PRO to the README.