### PR TITLE
Add wrapper for bottom sidebar in footer partial

### DIFF
--- a/views/partials/footer.blade.php
+++ b/views/partials/footer.blade.php
@@ -1,5 +1,7 @@
 @if (is_active_sidebar('bottom-sidebar'))
+  <div class="sidebar-bottom-fullwidth">
     <?php dynamic_sidebar('bottom-sidebar'); ?>
+  </div>
 @endif
 
 <footer class="main-footer hidden-print {{ get_field('scroll_elevator_enabled', 'option') ? 'scroll-elevator-toggle' : '' }}">


### PR DESCRIPTION
Modules placed in the "Bottom sidebar (full-width)" are currently placed directly under the body-tag. Wrapping this section makes it easier to control the layout of its content.