### PR TITLE
Fix warning for call to Illuminate Support

### DIFF
--- a/bem-views/404.blade.php
+++ b/bem-views/404.blade.php
@@ -9,4 +9,5 @@
     @endif
 
 @stop
-{{ /* THIS IS A SAMPLE VIEW */ }}
+
+{{-- THIS IS A SAMPLE VIEW --}}


### PR DESCRIPTION
Same as helsingborg-stad/Municipio#34, but for the master branch since develop falls after.

Fixes a logged error:

```
[Tue Apr 24 13:58:30 2018] PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Too few arguments to function e()
0 passed in wp-content/uploads/cache/blade-cache/dbfa6c3140a9f494b56948f15ea9fd5e1fb63e85.php on line 10 and at least 1 expected in vendor/illuminate/support/helpers.php:574
Stack trace:
#0 wp-content/uploads/cache/blade-cache/dbfa6c3140a9f494b56948f15ea9fd5e1fb63e85.php(10): e()
#1 vendor/illuminate/view/Engines/PhpEngine.php(43): include('...')
#2 vendor/illuminate/view/Engines/CompilerEngine.php(59): Illuminate\View\Engines\PhpEngine->evaluatePath('...' Array)
#3 vendor/illuminate/view/View.php(137): Illuminate\View\Engines\CompilerEngine->get('...' Array)
#4 vendor/illuminate/view/View.php(120):  in vendor/illuminate/support/helpers.php on line 574
```

Caused by Blade trying to do something with a PHP comment:

```php
<?php $__env->startSection('content'); ?>

    <?php if(file_exists(MUNICIPIO_PATH . '/views/partials/404/' . $post_type . '.blade.php')): ?>
        <?php echo $__env->make('partials.404.' . $post_type, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>
    <?php else: ?>
        <?php echo $__env->make('bem-views.partials.404.default', array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>
    <?php endif; ?>

<?php $__env->stopSection(); ?>
<?php echo e(/* THIS IS A SAMPLE VIEW */); ?>


<?php echo $__env->make('templates.master', array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>
```

The fix changes to a Blade comment instead: https://laravel.com/docs/5.6/blade#comments