### PR TITLE
Make builds consistent

### DIFF
--- a/library/Theme/Enqueue.php
+++ b/library/Theme/Enqueue.php
@@ -2,6 +2,7 @@
 
 namespace Municipio\Theme;
 
+use \Municipio\Helper\CacheBust;
 use \Municipio\Helper\Styleguide;
 
 class Enqueue
@@ -47,9 +48,11 @@ class Enqueue
 
     public function customizerStyle()
     {
+        $distUrl = get_template_directory_uri() . '/assets/dist/';
         $enqueueBem = apply_filters('Municipio/Theme/Enqueue/Bem', false);
+
         if ($enqueueBem) {
-            wp_register_style('municipio-customizer', get_template_directory_uri(). '/assets/dist/' . \Municipio\Helper\CacheBust::name('css/customizer.min.css'), '', null);
+            wp_register_style('municipio-customizer', $distUrl . CacheBust::name('css/customizer.css'), '', null);
             wp_enqueue_style('municipio-customizer');
         }
     }
@@ -72,10 +75,12 @@ class Enqueue
      */
     public function adminStyle()
     {
-        wp_register_style('helsingborg-se-admin', get_template_directory_uri(). '/assets/dist/' . \Municipio\Helper\CacheBust::name('css/admin.min.css'));
+        $distUri = get_template_directory_uri() . '/assets/dist/';
+
+        wp_register_style('helsingborg-se-admin', $distUri . CacheBust::name('css/admin.css'));
         wp_enqueue_style('helsingborg-se-admin');
 
-        wp_register_script('helsingborg-se-admin', get_template_directory_uri() . '/assets/dist/' . \Municipio\Helper\CacheBust::name('js/admin.js'));
+        wp_register_script('helsingborg-se-admin', $distUri . CacheBust::name('js/admin.js'));
         wp_enqueue_script('helsingborg-se-admin');
     }
 
@@ -85,6 +90,8 @@ class Enqueue
      */
     public function style()
     {
+        $distUri = get_template_directory_uri(). '/assets/dist/';
+
         // Tell jquery dependents to wait for prime instead.
         if (!apply_filters('Municipio/load-wp-jquery', false)) {
             wp_deregister_script('jquery');
@@ -100,7 +107,7 @@ class Enqueue
             wp_enqueue_style($this->defaultPrimeName . '-bem');
         }
 
-        wp_register_style('municipio', get_template_directory_uri(). '/assets/dist/' . \Municipio\Helper\CacheBust::name('css/app.css'));
+        wp_register_style('municipio', $distUri . CacheBust::name('css/app.css'));
         wp_enqueue_style('municipio');
     }
 
@@ -110,6 +117,7 @@ class Enqueue
      */
     public function script()
     {
+        $distUri = get_template_directory_uri() . '/assets/dist/';
         wp_register_script($this->defaultPrimeName, Styleguide::getScriptPath());
 
         //Localization
@@ -140,7 +148,7 @@ class Enqueue
         ));
         wp_enqueue_script($this->defaultPrimeName);
 
-        wp_register_script('municipio', get_template_directory_uri() . '/assets/dist/' . \Municipio\Helper\CacheBust::name('js/app.js'));
+        wp_register_script('municipio', $distUri . CacheBust::name('js/app.js'));
         wp_localize_script('municipio', 'MunicipioLang', array(
             'printbreak' => array(
                 'tooltip' => __('Insert Print Page Break tag', 'municipio')


### PR DESCRIPTION
Gulp builds appear to have had several issues:

- Files from previous builds were left behind, despite their sources being gone. This was true for the `tmp` directory as well, causing these old files to be added to the `dist` directory on every build by the `rev` task.
- Municipio loaded these old builds files, ignoring some of the newly generated files.
- The MCE scripts were concatenated into one big file, but were loaded as separate files.
- Tasks depended on the file system being case insensitive, which is usually not the case on Linux.
- Some tasks had race conditions, resulting in some files randomly not being generated.
- There was a task for building a vendor script, but no source files.
- JSHint could not print any warnings.

This commit fixes these issues.

**NOTE**: Make sure to test this carefully before considering merging. We're currently lagging behind on Municipio versions, and I have no other site to test this on myself.

A build now generates the following files:

```
assets/dist/css/admin.css
assets/dist/css/admin-e0568dc8e8.css
assets/dist/css/app.css
assets/dist/css/app-f9526422b3.css
assets/dist/css/customizer-03d1601c9a.css
assets/dist/css/customizer.css
assets/dist/images/helsingborg.svg
assets/dist/js/admin-522de1cf68.js
assets/dist/js/admin.js
assets/dist/js/app-1065be14c6.js
assets/dist/js/app.js
assets/dist/js/mce-buttons-43a593e35e.js
assets/dist/js/mce-buttons.js
assets/dist/js/mce-metadata-9e2b28629e.js
assets/dist/js/mce-metadata.js
assets/dist/js/mce-pricons-12cf3afeb1.js
assets/dist/js/mce-pricons.js
assets/dist/js/mce-print-break-8e19c25dc8.js
assets/dist/js/mce-print-break.js
assets/dist/rev-manifest.json
```