### PR TITLE
Use blade tag for PHP in archive search

### DIFF
--- a/views/partials/archive-filters/select.blade.php
+++ b/views/partials/archive-filters/select.blade.php
@@ -1,4 +1,4 @@
-<?php
+@php
     $selected = isset($_GET['filter'][$taxKey]) && $_GET['filter'][$taxKey] !== '-1' ? $_GET['filter'][$taxKey] : null;
 
     wp_dropdown_categories(array(
@@ -10,3 +10,4 @@
         'value_field' => 'slug',
         'selected' => $selected
     ));
+@endphp


### PR DESCRIPTION
Blade v5.8.8 seems to derp out when PHP tags aren't closed.

We should probably be using blade syntax either way.