### PR TITLE
Bug/event translation

### DIFF
--- a/assets/source/js/googleTranslate.js
+++ b/assets/source/js/googleTranslate.js
@@ -91,7 +91,7 @@ const Translate = class {
                 const prior = beforeElement || document.getElementsByTagName('script')[0];
 
                 script.async = async;
-                script.defer = defer;
+                script.defer = defer; 
 
                 function onloadHander(_, isAbort) {
                     if (

--- a/assets/source/js/googleTranslate.js
+++ b/assets/source/js/googleTranslate.js
@@ -2,6 +2,7 @@ import 'babel-polyfill';
 
 let googleTranslateLoaded = false;
 let resetQuery = false;
+
 /**
  * Translate class
  * @type {Translate}

--- a/views/partials/archive-filters.blade.php
+++ b/views/partials/archive-filters.blade.php
@@ -8,6 +8,8 @@
 
     <form method="get" action="{{ $archiveUrl }}" class="container" id="archive-filter">
 
+        <input id="hidden-translate" type="hidden" name="translate" value="" />  
+        <!-- {{ var_dump($archiveUrl) }} -->
         @if (isset($enabledTaxonomyFilters->highlighted) && !empty($enabledTaxonomyFilters->highlighted))
         @foreach ($enabledTaxonomyFilters->highlighted as $taxKey => $taxonomy)
         @if(count($taxonomy->values) > 1)
@@ -56,13 +58,38 @@
                 </div>
             </div>
             @endif   
-                    
+
             <script>
                 document.addEventListener('click', event => {
                     if(event.target === document.getElementById('filter-date-from') || event.target === document.getElementById('filter-date-to') ){
                         document.getElementById('ui-datepicker-div').classList.add('notranslate');
                     }
                 });
+                loadQueryString = () => { 
+                    let parameters = {}; 
+                    let searchString = location.search.substr(1); 
+                    let pairs = searchString.split("&"); 
+                    let parts;
+                    for(let i = 0; i < pairs.length; i++){
+                        parts = pairs[i].split("=");
+                        let name = parts[0];
+                        let data = decodeURI(parts[1]);
+                        parameters[name] = data;
+                    }    
+                    return parameters;
+                }
+
+                function processForm(e) {
+                    let formElement = document.getElementById('archive-filter');
+                    
+                    let oldUrlParams = loadQueryString();
+                    if(oldUrlParams.translate){
+                        document.getElementById('hidden-translate').value = oldUrlParams.translate;
+                    }
+                    return true;
+                }
+                document.getElementById('archive-filter').addEventListener("submit", processForm);
+
             </script>
 
             @if (isset($enabledTaxonomyFilters->primary) && !empty($enabledTaxonomyFilters->primary))

--- a/views/partials/archive-filters.blade.php
+++ b/views/partials/archive-filters.blade.php
@@ -55,7 +55,15 @@
                     <input type="text" name="to" placeholder="<?php _e('To date', 'municipio'); ?>" class="form-control datepicker-range datepicker-range-to" value="{{ isset($_GET['to']) && !empty($_GET['to']) ? sanitize_text_field($_GET['to']) : '' }}" readonly>
                 </div>
             </div>
-            @endif
+            @endif   
+                    
+            <script>
+                document.addEventListener('click', event => {
+                    if(event.target === document.getElementById('filter-date-from') || event.target === document.getElementById('filter-date-to') ){
+                        document.getElementById('ui-datepicker-div').classList.add('notranslate');
+                    }
+                });
+            </script>
 
             @if (isset($enabledTaxonomyFilters->primary) && !empty($enabledTaxonomyFilters->primary))
                 @foreach ($enabledTaxonomyFilters->primary as $taxKey => $tax)

--- a/views/partials/archive-filters.blade.php
+++ b/views/partials/archive-filters.blade.php
@@ -60,11 +60,13 @@
             @endif   
 
             <script>
-                document.addEventListener('click', event => {
-                    if(event.target === document.getElementById('filter-date-from') || event.target === document.getElementById('filter-date-to') ){
+                let els = [ document.getElementById('filter-date-from'), document.getElementById('filter-date-to')];
+                for(let el of els){
+                    el.addEventListener('click', event => {
                         document.getElementById('ui-datepicker-div').classList.add('notranslate');
-                    }
-                });
+                    });
+                }
+
                 loadQueryString = () => { 
                     let parameters = {}; 
                     let searchString = location.search.substr(1); 


### PR DESCRIPTION
Fixes two bugs concerning google translate and event filtering on archive pages. The first one was that you couldn't set dates when the translation was on.The second one that you lost the translation after searching/filtering. 

We added some js scripts to fix this into the blade template for the filter component, which is probably not ideal, but it works and it's specific to the template. 