### PR TITLE
Classic editor replacement

### DIFF
--- a/library/AcfFields/json/block-classic-editor.json
+++ b/library/AcfFields/json/block-classic-editor.json
@@ -1,0 +1,44 @@
+[
+    {
+        "key": "group_61556c32b3697",
+        "title": "Classic editor",
+        "fields": [
+            {
+                "key": "field_61556c50ecfd3",
+                "label": "Content",
+                "name": "content",
+                "type": "wysiwyg",
+                "instructions": "",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 1,
+                "delay": 0
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "block",
+                    "operator": "==",
+                    "value": "acf\/classic"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": ""
+    }
+]

--- a/library/AcfFields/php/block-classic-editor.php
+++ b/library/AcfFields/php/block-classic-editor.php
@@ -1,0 +1,48 @@
+<?php
+
+if( function_exists('acf_add_local_field_group') ):
+
+acf_add_local_field_group(array(
+	'key' => 'group_61556c32b3697',
+	'title' => 'Classic editor',
+	'fields' => array(
+		array(
+			'key' => 'field_61556c50ecfd3',
+			'label' => 'Content',
+			'name' => 'content',
+			'type' => 'wysiwyg',
+			'instructions' => '',
+			'required' => 1,
+			'conditional_logic' => 0,
+			'wrapper' => array(
+				'width' => '',
+				'class' => '',
+				'id' => '',
+			),
+			'default_value' => '',
+			'tabs' => 'all',
+			'toolbar' => 'full',
+			'media_upload' => 1,
+			'delay' => 0,
+		),
+	),
+	'location' => array(
+		array(
+			array(
+				'param' => 'block',
+				'operator' => '==',
+				'value' => 'acf/classic',
+			),
+		),
+	),
+	'menu_order' => 0,
+	'position' => 'normal',
+	'style' => 'default',
+	'label_placement' => 'top',
+	'instruction_placement' => 'label',
+	'hide_on_screen' => '',
+	'active' => true,
+	'description' => '',
+));
+
+endif;

--- a/library/Admin/Gutenberg/Blocks/BlockManager.php
+++ b/library/Admin/Gutenberg/Blocks/BlockManager.php
@@ -1,0 +1,130 @@
+<?php
+namespace Municipio\Admin\Gutenberg\Blocks;
+
+use Municipio\Template as Template;
+
+class BlockManager {
+    public function __construct() {
+        add_filter('Municipio/blade/view_paths', array($this, 'getViewPath'), 10);
+        $this->registerBlocks();
+    }
+
+    //Register block
+    public function registerBlocks() {
+        // Check function exists.
+        if( function_exists('acf_register_block_type') ) {
+
+            // register a testimonial block.
+            acf_register_block_type(array(
+                'name'              => 'button',
+                'title'             => __('Button', 'municipio'),
+                'description'       => __('A button block', 'municipio'),
+                'render_callback'   => array($this, 'renderCallback'),
+                'category'          => 'formatting',
+                'icon'              => 'button',
+                'keywords'          => array('button', 'link'),
+                'supports'          => [
+                    'align' => true
+                ],
+                'view'              => 'button'
+            ));
+
+            acf_register_block_type(array(
+                'name'              => 'classic',
+                'title'             => __('Classic', 'municipio'),
+                'description'       => __('A block that lets you create and edit articles', 'municipio'),
+                'render_callback'   => array($this, 'renderCallback'),
+                'category'          => 'formatting',
+                'icon'              => 'text',
+                'keywords'          => array('editor', 'classic'),
+                'supports'          => [
+                    'align' => true
+                ],
+                'view'              => 'classic'
+            ));
+        }
+    }
+
+    //Callback for render, builds view with blade engine
+    public function renderCallback($block) {
+        $data = $this->buildData($block['data']);
+        $data['classList'] = $this->buildBlockClassList($block);
+        $template = new Template();        
+
+        if($this->validateFields($block['data'])) {
+            $template->renderView($block['view'], $data);
+        } else {
+            $template->renderView('default', ['blockTitle' => $block['title'], 'message' => __('Please fill in all required fields.')]);
+        }
+
+    }
+
+    //Returns view path
+    public function getViewPath($paths) {
+        $paths[] = plugin_dir_path( __FILE__ ) . 'views';
+
+        return $paths;
+    }
+
+    // Build data my getting value from field id and format key
+    public function buildData($data) {
+        $newData = [];
+        foreach($data as $key => $value) {
+            $key = ltrim($key, '_');
+            $newValue = get_field($value);
+            
+            if(str_contains($value, 'field_')) {
+                $newData[$key] = get_field($value);
+            } else {
+                $newData[get_field_object($key)['name']] = $value;
+            }
+        }
+
+        return $newData;
+    }
+
+    public function buildBlockClassList($block)
+    {
+        $classList = ['t-block-container'];
+
+        if(isset($block['align'])) {
+            $classList[] = "t-block-align-" . $block['align'];
+        }
+
+        return implode(' ', $classList);
+    }
+
+    /**
+         * Validates the required fields
+         * @return boolean
+         */
+        private function validateFields($fields) {        
+            
+            $valid = true;            
+
+            foreach($fields as $key => $value) {    
+                
+                if(is_string($key) && is_string($value)) {
+                    if(str_contains($key, 'field_')) {
+                        $field = $key;
+                    } elseif(str_contains($value, 'field_')) {
+                        $field = $value;
+                    }
+                }
+
+                $fieldObject = get_field_object($field);
+                //Skip validation of decendants
+                if(isset($fieldObject['parent']) && str_contains($fieldObject['parent'], 'field_')) {
+                    continue;
+                }
+                
+                //Check if required field has a value
+                if($fieldObject['required'] && (!$fieldObject['value'] && $fieldObject['value'] !== "0")) {
+                    $valid = false;
+                }
+                
+            }
+
+            return $valid;
+        }
+}

--- a/library/Admin/Gutenberg/Blocks/BlockManager.php
+++ b/library/Admin/Gutenberg/Blocks/BlockManager.php
@@ -71,7 +71,6 @@ class BlockManager {
         $newData = [];
         foreach($data as $key => $value) {
             $key = ltrim($key, '_');
-            $newValue = get_field($value);
             
             if(str_contains($value, 'field_')) {
                 $newData[$key] = get_field($value);

--- a/library/Admin/Gutenberg/Blocks/views/button.blade.php
+++ b/library/Admin/Gutenberg/Blocks/views/button.blade.php
@@ -1,0 +1,10 @@
+<div class="{!! $classList !!}">
+    @button([
+        'text' => $text,
+        'color' => $color,
+        'style' => $style,
+        'size' => $size,
+        'href' => $link
+    ])
+    @endbutton
+</div>

--- a/library/Admin/Gutenberg/Blocks/views/classic.blade.php
+++ b/library/Admin/Gutenberg/Blocks/views/classic.blade.php
@@ -1,0 +1,3 @@
+@if(!empty($content))
+    {!! $content !!}    
+@endif

--- a/library/Admin/Gutenberg/Blocks/views/default.blade.php
+++ b/library/Admin/Gutenberg/Blocks/views/default.blade.php
@@ -1,0 +1,10 @@
+@notice([
+    'type' => 'info',
+    'icon' => [
+        'name' => 'report',
+        'size' => 'md',
+        'color' => 'primary'
+    ]
+])
+    {!! '<b>' . $blockTitle . '</b>'. ': ' . $message !!}
+@endnotice

--- a/library/App.php
+++ b/library/App.php
@@ -68,7 +68,7 @@ class App
         new \Municipio\Admin\General();
         new \Municipio\Admin\LoginTracking();
 
-        new \Municipio\Admin\Gutenberg\Blocks\Button();
+        new \Municipio\Admin\Gutenberg\Blocks\BlockManager();
 
         new \Municipio\Admin\ExternalDeptendents(); 
 

--- a/library/Bootstrap.php
+++ b/library/Bootstrap.php
@@ -36,6 +36,10 @@ add_action('init', function () {
     $acfExportManager->setTextdomain('municipio');
     $acfExportManager->setExportFolder(MUNICIPIO_PATH . 'library/AcfFields');
     $acfExportManager->autoExport(array(
+        // Blocks
+        'block-classic-editpr'                      => 'group_61556c32b3697',
+        'block-button'                              => 'group_60acdac5158f2',
+        // Options
         'options-page-display'                      => 'group_56c33cf1470dc',
         'options-page-navigation'                   => 'group_56d83cff12bb3',
         'options-theme-404'                         => 'group_56d41dbd7e501',


### PR DESCRIPTION
Add a new block that utilizes wysiwyg editor field to
replace the classic editor because a known issue with creating links.

Repurpose the button class. Making it able to register and render any
block created within Municipio.

Add a notice that is shown when required fields are not filled in.