### PR TITLE
moved content-area-top module above filter section

### DIFF
--- a/views/v3/templates/archive.blade.php
+++ b/views/v3/templates/archive.blade.php
@@ -29,6 +29,8 @@
         </article>
     @endif
 
+    @includeIf('partials.sidebar', ['id' => 'content-area-top', 'classes' => ['o-grid']])
+
     @includeFirst([
         "partials.archive.archive-" . sanitize_title($postType) . "-filters",
         "partials.archive.archive-filters"
@@ -37,8 +39,6 @@
     <div class="archive s-archive s-archive-template-{{sanitize_title($template)}}  s-{{sanitize_title($postType)}}-archive">
         
         {!! $hook->loopStart !!}
-
-        @includeIf('partials.sidebar', ['id' => 'content-area-top', 'classes' => ['o-grid']])
 
         @includeWhen($archiveMenuItems, 'partials.archive.archive-menu')
 


### PR DESCRIPTION
moved content-area-top module above filter section

![Screenshot 2022-05-30 at 16 43 37](https://user-images.githubusercontent.com/21363149/171015914-e88676b6-0a57-47b5-85ac-f6bc1e8ea26f.png)

