### PR TITLE
Replaced ch with px and setting all article children to same width

### DIFF
--- a/assets/source/3.0/sass/article.scss
+++ b/assets/source/3.0/sass/article.scss
@@ -1,7 +1,7 @@
 .c-article {
     max-width: 1328px;
 
-    p {
-        max-width: 95ch;
+    &>* {
+        max-width: 904px;
     }
 }

--- a/assets/source/3.0/sass/article.scss
+++ b/assets/source/3.0/sass/article.scss
@@ -1,7 +1,8 @@
 .c-article {
     max-width: 1328px;
+    margin: 0 auto;
 
-    &>* {
+    p {
         max-width: 904px;
     }
 }


### PR DESCRIPTION
Not sure if this is the "correct" way to do it. But I set all the child items of an article to have the same "max-width" as the maximum width of "content" in municipio. 