### PR TITLE
Date format in time since comment

### DIFF
--- a/views/v3/partials/comments.blade.php
+++ b/views/v3/partials/comments.blade.php
@@ -17,7 +17,7 @@
                         'icon' => 'face',
                         'bubble_color' => 'light',
                         'date_suffix' => __('ago', 'municipio'),
-                        'date' => date($dateTimeFormat, strtotime($comment->comment_date)),
+                        'date' => date("Y-m-d H:i:s", strtotime($comment->comment_date)),
                         'classList' => [
                             'comment-'.$comment->comment_ID, 
                             'c-comment--level-1',
@@ -88,7 +88,7 @@
                                 'icon' => 'face',
                                 'bubble_color' => 'light',
                                 'date_suffix' => __('ago', 'municipio'),
-                                'date' => date($dateTimeFormat, strtotime($answer->comment_date)),
+                                'date' => date("Y-m-d H:i:s", strtotime($answer->comment_date)),
                                 'is_reply' => true,
                                 'classList' => [
                                     'c-comment--level-2',


### PR DESCRIPTION
Reverted to not using WP date format settings for comments. Since strotime is used it should work with standard date/time formats, but helsingborg.se had added a comma, which broke the time calculation. Moreover it superflous, since it is here only used by the date component for computing elapsed time.