### PR TITLE
3.0/fix/php errors

### DIFF
--- a/library/Controller/BaseController.php
+++ b/library/Controller/BaseController.php
@@ -157,7 +157,7 @@ class BaseController
 
         //Current posttype
         $this->data['postTypeDetails']      = \Municipio\Helper\PostType::postTypeDetails();
-        $this->data['postType']             = $this->data['postTypeDetails']->name;
+        $this->data['postType']             = $this->data['postTypeDetails']->name ?? '';
 
         //Notice storage
         $this->data['notice']               = [];

--- a/library/Controller/BaseController.php
+++ b/library/Controller/BaseController.php
@@ -349,7 +349,7 @@ class BaseController
      */
     public function getFloatingMenuLabels() : object
     {
-        $menuObject = wp_get_nav_menu_object(get_nav_menu_locations()['floating-menu']); 
+        $menuObject = wp_get_nav_menu_object(get_nav_menu_locations()['floating-menu'] ?? ''); 
 
         return (object) apply_filters('Municipio/FloatingMenuLabels', 
             [
@@ -367,7 +367,7 @@ class BaseController
      */
     public function getLanguageMenuOptions() : object
     {
-        $options = wp_get_nav_menu_object(get_nav_menu_locations()['language-menu']);
+        $options = wp_get_nav_menu_object(get_nav_menu_locations()['language-menu'] ?? '');
         
         $options = [
             'disclaimer'        => get_field('language_menu_disclaimer', $options),
@@ -384,7 +384,7 @@ class BaseController
      */
     public function getQuicklinksOptions() : object
     {
-        $options = wp_get_nav_menu_object(get_nav_menu_locations()['quicklinks-menu']); 
+        $options = wp_get_nav_menu_object(get_nav_menu_locations()['quicklinks-menu'] ?? ''); 
 
         $options = [
             'backgroundColor'   => get_field('quicklinks_background_color', $options),

--- a/library/Helper/ElementAttribute.php
+++ b/library/Helper/ElementAttribute.php
@@ -46,7 +46,7 @@ class ElementAttribute
 
     public function addAttribute($attribute, $values = '')
     {
-        if (!is_string($attribute) && !is_array($attribute) || !is_string($values) && !is_array($values) && !is_array($attribute) || empty($attribute) || is_string($attributes) && empty($values)) {
+        if (!is_string($attribute) && !is_array($attribute) || !is_string($values) && !is_array($values) && !is_array($attribute) || empty($attribute) || is_string($attribute) && empty($values)) {
             return false;
         }
 

--- a/library/Helper/ElementAttribute.php
+++ b/library/Helper/ElementAttribute.php
@@ -46,7 +46,16 @@ class ElementAttribute
 
     public function addAttribute($attribute, $values = '')
     {
-        if (!is_string($attribute) && !is_array($attribute) || !is_string($values) && !is_array($values) && !is_array($attribute) || empty($attribute) || is_string($attribute) && empty($values)) {
+        if (
+            !is_string($attribute)
+            && !is_array($attribute)
+            || !is_string($values)
+            && !is_array($values)
+            && !is_array($attribute)
+            || empty($attribute)
+            || is_string($attribute)
+            && empty($values)
+        ) {
             return false;
         }
 

--- a/views/v3/partials/loop.blade.php
+++ b/views/v3/partials/loop.blade.php
@@ -1,7 +1,6 @@
-
 {!! $hook->innerLoopStart !!}
 
-@if($post)
+@if (!empty($post))
     @include('partials.article', (array) $post)
 @endif
 

--- a/views/v3/partials/post/post-compressed.blade.php
+++ b/views/v3/partials/post/post-compressed.blade.php
@@ -22,7 +22,7 @@
             </article>
 
             <!-- Dates -->
-            @if($post->archiveDate)
+            @if(!empty($post->archiveDate))
                 @typography(['variant' => 'meta', 'element' => 'p', 'classList' => ['archive-compressed__date', 'u-margin__top--4']])
                     {{$lang->publish}}: 
                     @date([

--- a/views/v3/partials/signature.blade.php
+++ b/views/v3/partials/signature.blade.php
@@ -1,24 +1,26 @@
 <!-- Signature -->
-@if($postTypeDetails->hierarchical)
-  @signature([
-      'author' => $signature->name, 
-      'published' => $signature->published,
-      'updated' => $signature->updated,
-      'avatar_size' => 'sm',
-      'avatar' => $signature->avatar,
-      'authorRole' => $signature->role,
-      'link' => $signature->link,
-      'updatedLabel' => $publishTranslations->updated,
-      'publishedLabel' => $publishTranslations->publish,
-      'classList' => $classList
-  ])
-  @endsignature
-@elseif(!$postTypeDetails->hierarchical && $postType == 'post')
-  @signature([
-      'published' => $signature->publish,
-      'updated' => $signature->updated,
-      'updatedLabel' => $publishTranslations->updated,
-      'publishedLabel' => $publishTranslations->publish,
-  ])
-  @endsignature
+@if (!empty($signature))
+    @if ($postTypeDetails->hierarchical)
+        @signature([
+            'author' => $signature->name,
+            'published' => $signature->published,
+            'updated' => $signature->updated,
+            'avatar_size' => 'sm',
+            'avatar' => $signature->avatar,
+            'authorRole' => $signature->role,
+            'link' => $signature->link,
+            'updatedLabel' => $publishTranslations->updated,
+            'publishedLabel' => $publishTranslations->publish,
+            'classList' => $classList
+        ])
+        @endsignature
+    @elseif(!$postTypeDetails->hierarchical && $postType == 'post')
+        @signature([
+            'published' => $signature->publish,
+            'updated' => $signature->updated,
+            'updatedLabel' => $publishTranslations->updated,
+            'publishedLabel' => $publishTranslations->publish
+        ])
+        @endsignature
+    @endif
 @endif

--- a/views/v3/partials/signature.blade.php
+++ b/views/v3/partials/signature.blade.php
@@ -1,6 +1,6 @@
 <!-- Signature -->
-@if (!empty($signature))
-    @if ($postTypeDetails->hierarchical)
+@if (!empty($signature) && !empty($postTypeDetails))
+    @if ($postTypeDetails->hierarchical && !empty($publishTranslations))
         @signature([
             'author' => $signature->name,
             'published' => $signature->published,
@@ -11,7 +11,7 @@
             'link' => $signature->link,
             'updatedLabel' => $publishTranslations->updated,
             'publishedLabel' => $publishTranslations->publish,
-            'classList' => $classList
+            'classList' => $classList ?? []
         ])
         @endsignature
     @elseif(!$postTypeDetails->hierarchical && $postType == 'post')


### PR DESCRIPTION
Fixes undefined values and other stuff that trigger PHP errors.

Fixes:
- Check for signature object before using it (signature.blade.php)
- Check for $post->archiveDate property before using it (post-compressed.blade.php)
- PostType name is not always defined in eg. 404 pages (BaseController.php)
- Set empty string when the targeted menu is not configured (BaseController.php)
- Fix typo (Helper/ElementAttribute.php)