### PR TITLE
Normalize px to em fonts

### DIFF
--- a/library/Customizer/Applicators/Css.php
+++ b/library/Customizer/Applicators/Css.php
@@ -4,7 +4,7 @@ namespace Municipio\Customizer\Applicators;
 
 class Css
 {
-  private static $baseFontSize = '16px';
+  private $baseFontSize = '16px';
 
   public function __construct() {
     add_filter('kirki_' . \Municipio\Customizer::KIRKI_CONFIG . '_styles', array($this, 'filterPageWidth'));
@@ -49,7 +49,6 @@ class Css
   public function filterFontSize($styles): array 
   {
     $baseSize = $this->getBaseFontSize($styles['global'][':root']); 
-
     foreach($styles['global'][':root'] as $key => &$item) {
       if($this->canTransformValue($key, $item)) {
         $item = $this->makePxValueNumeric($item) / $baseSize . 'em';
@@ -84,13 +83,14 @@ class Css
    */
   private function getBaseFontSize($styles): int
   {
-    if(is_array($style) && !empty($style)) {
+    if(is_array($styles) && !empty($styles)) {
       foreach($styles as $key => $style) {
         if($key == '--font-size-base') {
-          $this->makePxValueNumeric($style); 
+          return $this->makePxValueNumeric($style); 
         }
       }
     }
+
     return $this->makePxValueNumeric(
       $this->baseFontSize
     );
@@ -104,6 +104,11 @@ class Css
    */
   private function makePxValueNumeric($value): int
   {
-    return (int) str_replace('px', '', $value); 
+    $value = str_replace('px', '', $value); 
+
+    if(is_numeric($value) && !empty($value)) {
+      return (int) $value;
+    }
+    return (int) str_replace('px', '', $this->baseFontSize);
   }
 }

--- a/library/Customizer/Applicators/Css.php
+++ b/library/Customizer/Applicators/Css.php
@@ -4,8 +4,11 @@ namespace Municipio\Customizer\Applicators;
 
 class Css
 {
+  private static $baseFontSize = '16px';
+
   public function __construct() {
     add_filter('kirki_' . \Municipio\Customizer::KIRKI_CONFIG . '_styles', array($this, 'filterPageWidth'));
+    add_filter('kirki_' . \Municipio\Customizer::KIRKI_CONFIG . '_styles', array($this, 'filterFontSize'));   
   }
 
   /**
@@ -35,5 +38,72 @@ class Css
     }
  
     return $styles; 
+  }
+
+  /**
+   * Make font sizes in pixels, to rm.
+   *
+   * @param array $styles
+   * @return array $styles
+   */
+  public function filterFontSize($styles): array 
+  {
+    $baseSize = $this->getBaseFontSize($styles['global'][':root']); 
+
+    foreach($styles['global'][':root'] as $key => &$item) {
+      if($this->canTransformValue($key, $item)) {
+        $item = $this->makePxValueNumeric($item) / $baseSize . 'em';
+      }
+    }
+    return $styles;
+  }
+
+  /**
+   * Check if value should be transformed
+   *
+   * @param string $key
+   * @param string $value
+   * @return boolean
+   */
+  private function canTransformValue($key, $value): bool
+  {
+    if(!strpos($key, 'font')) {
+      return false;
+    }
+    if(!strpos($value, 'px')) {
+      return false; 
+    }
+    return true; 
+  } 
+
+  /**
+   * Get the base font size
+   *
+   * @param array $styles
+   * @return integer $baseFontSize
+   */
+  private function getBaseFontSize($styles): int
+  {
+    if(is_array($style) && !empty($style)) {
+      foreach($styles as $key => $style) {
+        if($key == '--font-size-base') {
+          $this->makePxValueNumeric($style); 
+        }
+      }
+    }
+    return $this->makePxValueNumeric(
+      $this->baseFontSize
+    );
+  }
+
+  /**
+   * Transform a px valiue to integer
+   *
+   * @param string $value Value with unit
+   * @return int $value Value without unit
+   */
+  private function makePxValueNumeric($value): int
+  {
+    return (int) str_replace('px', '', $value); 
   }
 }

--- a/library/Customizer/Applicators/Css.php
+++ b/library/Customizer/Applicators/Css.php
@@ -83,7 +83,7 @@ class Css
    */
   private function getBaseFontSize($styles): int
   {
-    if(is_array($styles) && !empty($styles)) {
+    if(is_iterable($styles)) {
       foreach($styles as $key => $style) {
         if($key == '--font-size-base') {
           return $this->makePxValueNumeric($style); 


### PR DESCRIPTION
Make any font value entered in PX to resolve to a em value. Only applies if the following rules apply: 

- CSS Applicator is used
- Unit is in PX 
- Key contains 'font'