### PR TITLE
Removes the archive related settings from error msg

### DIFF
--- a/assets/source/3.0/js/admin/designShare.js
+++ b/assets/source/3.0/js/admin/designShare.js
@@ -38,7 +38,9 @@ export default (() => {
                     const scrubbedValue = scrubHexValue(value);
                     control.setting.set(scrubbedValue);
                   } else {
-                    incompatibleKeyStack.push(key);
+                    if(!key.startsWith('archive_')) {
+                      incompatibleKeyStack.push(key);
+                    }
                   }
                 }
 


### PR DESCRIPTION
Using startsWith instead of includes if a key contains something like posts_archive_bg_color