### PR TITLE
feat: Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CHANGELOG.md from [@nramstedt](https://github.com/nramstedt).
+- Example release in CHANGELOG.md (0.0.0)
 
-## [X.X.X] - 20XX-XX-XX
+## [0.0.0] - 1970-12-01
 
 ### Added
 
@@ -29,4 +30,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Another lorem ipsu fix
 
 [unreleased]: https://github.com/helsingborg-stad/municipio/compare/d14521595606482634fb3568dc2ea8f07a36286e...HEAD
-[X.X.X]: https://github.com/helsingborg-stad/municipio/compare/1.33.4...HEAD
+[0.0.0]: https://github.com/helsingborg-stad/municipio/compare/1.33.4...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- CHANGELOG.md from [@nramstedt](https://github.com/nramstedt).
+
+## [X.X.X] - 20XX-XX-XX
+
+### Added
+
+- Example swedish translation for example module from [@nramstedt](https://github.com/nramstedt).
+- Example template for psudo examples
+
+### Changed
+
+- Changed example class to psudo class from [@nramstedt](https://github.com/nramstedt).
+- Improved example feature
+
+### Fixed
+
+- Example fixes from [@nramstedt](https://github.com/nramstedt).
+- Another lorem ipsu fix
+
+[unreleased]: https://github.com/helsingborg-stad/municipio/compare/d14521595606482634fb3568dc2ea8f07a36286e...HEAD
+[X.X.X]: https://github.com/helsingborg-stad/municipio/compare/1.33.4...HEAD


### PR DESCRIPTION
Add CHANGELOG.md based on [keep-a-changelog](https://github.com/olivierlacan/keep-a-changelog/blob/main/CHANGELOG.md). Basically during development we add items in Added, Changed or Fixed - which later becomes a release (see example release in CHANGELOG.md). 

Additional resources regarding changelog managment: https://keepachangelog.com/en/1..0/ 