### PR TITLE
Feature/implementera evenemang i purpose templates cu 865bj28hw

### DIFF
--- a/library/AcfFields/json/purpose-place.json
+++ b/library/AcfFields/json/purpose-place.json
@@ -29,6 +29,13 @@
                 "operator": "==",
                 "value": "place"
             }
+        ],
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "place"
+            }
         ]
     ],
     "menu_order": 0,

--- a/library/AcfFields/php/purpose-place.php
+++ b/library/AcfFields/php/purpose-place.php
@@ -1,7 +1,7 @@
-<?php
+<?php 
 
-if (function_exists('acf_add_local_field_group')) {
-    acf_add_local_field_group(array(
+if (function_exists('acf_add_local_field_group')) {
+    acf_add_local_field_group(array(
     'key' => 'group_63eb4a0aa476e',
     'title' => __('Location', 'municipio'),
     'fields' => array(
@@ -33,6 +33,13 @@ if (function_exists('acf_add_local_field_group')) {
                 'value' => 'place',
             ),
         ),
+        1 => array(
+            0 => array(
+                'param' => 'post_type',
+                'operator' => '==',
+                'value' => 'place',
+            ),
+        ),
     ),
     'menu_order' => 0,
     'position' => 'normal',
@@ -48,5 +55,5 @@ if (function_exists('acf_add_local_field_group')) {
     'acfe_form' => 0,
     'acfe_meta' => '',
     'acfe_note' => '',
-    ));
-}
+));
+}

--- a/library/Admin/Acf/LocationRulesPurpose.php
+++ b/library/Admin/Acf/LocationRulesPurpose.php
@@ -12,36 +12,35 @@ class LocationRulesPurpose extends \ACF_Location // @codingStandardsIgnoreLine
 
     public function get_values($rule) // @codingStandardsIgnoreLine
     {
-        return \Municipio\Helper\Purpose::getRegisteredPurposes();
+        return \Municipio\Helper\Purpose::getRegisteredPurposes(false);
     }
 
     public function match($rule, $screen, $field_group)
     {
-        if (isset($screen['taxonomy_list'])) {
+
+        if (!empty($screen['taxonomy_list'])) {
             $type = $screen['taxonomy_list'];
-        } elseif (isset($screen['post_id'])) {
+        } elseif (!empty($screen['post_id'])) {
             $post_id = $screen['post_id'];
             $post = get_post($post_id);
             if (!$post) {
                 return $rule;
+            } else {
+                $type = $post->post_type;
             }
-            $type = $post->post_type;
         } else {
             return false;
         }
-
         // Compare the post attribute to rule value.
-        $purposes = \Municipio\Helper\Purpose::getPurpose($type);
-        $purpose = $purposes['main'] ?? null;
-
-        if (!$purpose) {
+        $purpose = \Municipio\Helper\Purpose::getPurpose($type);
+        if ('' === $purpose) {
             return false;
         }
 
         $result = ($purpose === $rule['value']);
 
         // Return result taking into account the operator type.
-        if ($rule['operator'] === '!=') {
+        if ($rule['operator'] == '!=') {
             return !$result;
         }
         return $result;

--- a/library/Admin/Acf/LocationRulesPurpose.php
+++ b/library/Admin/Acf/LocationRulesPurpose.php
@@ -31,14 +31,14 @@ class LocationRulesPurpose extends \ACF_Location // @codingStandardsIgnoreLine
         }
 
         // Compare the post attribute to rule value.
-        $purposes = \Municipio\Helper\Purpose::getPurposes($type);
-        $mainPurpose = $purposes['main'] ?? null;
+        $purposes = \Municipio\Helper\Purpose::getPurpose($type);
+        $purpose = $purposes['main'] ?? null;
 
-        if (!$mainPurpose) {
+        if (!$purpose) {
             return false;
         }
 
-        $result = ($mainPurpose === $rule['value']);
+        $result = ($purpose === $rule['value']);
 
         // Return result taking into account the operator type.
         if ($rule['operator'] === '!=') {

--- a/library/Admin/Acf/LocationRulesPurpose.php
+++ b/library/Admin/Acf/LocationRulesPurpose.php
@@ -12,7 +12,7 @@ class LocationRulesPurpose extends \ACF_Location // @codingStandardsIgnoreLine
 
     public function get_values($rule) // @codingStandardsIgnoreLine
     {
-        return \Municipio\Helper\Purpose::getRegisteredPurposes(false);
+        return \Municipio\Helper\Purpose::getRegisteredPurposes();
     }
 
     public function match($rule, $screen, $field_group)

--- a/library/Admin/Acf/LocationRulesPurpose.php
+++ b/library/Admin/Acf/LocationRulesPurpose.php
@@ -20,8 +20,8 @@ class LocationRulesPurpose extends \ACF_Location // @codingStandardsIgnoreLine
         if (!empty($screen['taxonomy_list'])) {
             $type = $screen['taxonomy_list'];
         } elseif (!empty($screen['post_id'])) {
-            $post_id = $screen['post_id'];
-            $post = get_post($post_id);
+            $postId = $screen['post_id'];
+            $post = get_post($postId);
             if (!$post) {
                 return $rule;
             } else {

--- a/library/Admin/Acf/LocationRulesPurpose.php
+++ b/library/Admin/Acf/LocationRulesPurpose.php
@@ -17,7 +17,6 @@ class LocationRulesPurpose extends \ACF_Location // @codingStandardsIgnoreLine
 
     public function match($rule, $screen, $field_group)
     {
-
         if (!empty($screen['taxonomy_list'])) {
             $type = $screen['taxonomy_list'];
         } elseif (!empty($screen['post_id'])) {
@@ -32,17 +31,20 @@ class LocationRulesPurpose extends \ACF_Location // @codingStandardsIgnoreLine
             return false;
         }
         // Compare the post attribute to rule value.
-        $purpose = \Municipio\Helper\Purpose::getPurpose($type);
-        if ('' === $purpose) {
-            return false;
+        $purposes = \Municipio\Helper\Purpose::getPurpose($type, true);
+        if (!empty($purposes)) {
+            foreach ($purposes as $purpose) {
+                $result = ($purpose->key === $rule['value']);
+                $returnResult = $result;
+                // Return result taking into account the operator type.
+                if ($rule['operator'] == '!=') {
+                    $returnResult = !$result;
+                }
+            }
+        } else {
+            $returnResult = false;
         }
 
-        $result = ($purpose === $rule['value']);
-
-        // Return result taking into account the operator type.
-        if ($rule['operator'] == '!=') {
-            return !$result;
-        }
-        return $result;
+        return $returnResult;
     }
 }

--- a/library/Admin/Acf/LocationRulesPurpose.php
+++ b/library/Admin/Acf/LocationRulesPurpose.php
@@ -17,29 +17,31 @@ class LocationRulesPurpose extends \ACF_Location // @codingStandardsIgnoreLine
 
     public function match($rule, $screen, $field_group)
     {
-
-        if (!empty($screen['taxonomy_list'])) {
+        if (isset($screen['taxonomy_list'])) {
             $type = $screen['taxonomy_list'];
-        } elseif (!empty($screen['post_id'])) {
-            $post_id = $screen['taxonomy_list'];
+        } elseif (isset($screen['post_id'])) {
+            $post_id = $screen['post_id'];
             $post = get_post($post_id);
             if (!$post) {
                 return $rule;
-            } else {
-                $type = $post->post_type;
             }
+            $type = $post->post_type;
         } else {
             return false;
         }
+
         // Compare the post attribute to rule value.
         $purposes = \Municipio\Helper\Purpose::getPurposes($type);
-        if (empty($purposes['main'])) {
+        $mainPurpose = $purposes['main'] ?? null;
+
+        if (!$mainPurpose) {
             return false;
         }
-        $result = ($purposes['main'] == $rule['value']);
+
+        $result = ($mainPurpose === $rule['value']);
 
         // Return result taking into account the operator type.
-        if ($rule['operator'] == '!=') {
+        if ($rule['operator'] === '!=') {
             return !$result;
         }
         return $result;

--- a/library/Controller/Purpose/Event.php
+++ b/library/Controller/Purpose/Event.php
@@ -15,4 +15,83 @@ class Event extends PurposeFactory
 
         parent::__construct($this->key, $this->label, ['place' => Place::class]);
     }
+
+    public function init(): void
+    {
+        // Append structured data for schema.org markup
+        add_filter('Municipio/StructuredData', [$this, 'appendStructuredData'], 10, 3);
+    }
+/**
+ * Appends the structured data array (used for schema.org markup) with additional data for events.
+ *
+ * @param array $structuredData The structured data to append event data to.
+ * @param string $postType The post type of the post.
+ * @param int $postId The ID of the post to retrieve event data for.
+ *
+ * @return array The updated structured data.
+ */
+    public function appendStructuredData(array $structuredData, string $postType, int $postId): array
+    {
+        if (empty($postId)) {
+            return $structuredData;
+        }
+
+        // Retrieve the event post meta data
+        $eventMeta = get_post_meta($postId);
+
+        // Event dates
+        $startDate = '';
+        $endDate = '';
+        if (isset($eventMeta['occasions_complete']) && is_array($eventMeta['occasions_complete'])) {
+            $occasions = maybe_unserialize($eventMeta['occasions_complete'][0]);
+            if (isset($occasions['start_date'])) {
+                $startDate = $occasions['start_date'];
+            }
+            if (isset($occasions['end_date'])) {
+                $endDate = $occasions['end_date'];
+            }
+        }
+
+        $thumbId = isset($eventMeta['_thumbnail_id'][0]) ? $eventMeta['_thumbnail_id'][0] : false;
+        $imageUrl = $thumbId ? wp_get_attachment_url($thumbId) : '';
+
+        // Build the schema.org event data
+        $eventData = [
+            '@type'       => 'Event',
+            'name'        => get_the_title($postId),
+            'startDate'   => $startDate,
+            'endDate'     => $endDate,
+            'description' => get_the_excerpt($postId),
+            'image'       => $imageUrl,
+            'offers'      => [],
+        ];
+
+        // Event tickets
+        if (isset($eventMeta['booking_link']) && isset($eventMeta['booking_link'][0])) {
+            $eventData['offers'] = [
+            '@type' => 'Offer',
+            'name'  => 'ticket',
+            'url'   => $eventMeta['booking_link'][0],
+            ];
+        }
+
+        if (isset($eventMeta['additional_ticket_types']) && is_array($eventMeta['additional_ticket_types']) && isset($eventMeta['additional_ticket_types'][0])) {
+            $additionalTypes = [];
+            $ticketTypes = maybe_unserialize($eventMeta['additional_ticket_types'][0]);
+            foreach ($ticketTypes as $type) {
+                if (isset($type['ticket_name']) && isset($type['maximum_price'])) {
+                    $additionalTypes[] = [
+                    '@type'         => 'Offer',
+                    'name'          => $type['ticket_name'],
+                    'price'         => $type['maximum_price'],
+                    'priceCurrency' => 'SEK',
+                    ];
+                }
+            }
+            $eventData['offers'] = array_merge($eventData['offers'], $additionalTypes);
+        }
+
+        // Append the event data to the structured data
+        return array_merge($eventData, $structuredData);
+    }
 }

--- a/library/Controller/Purpose/Event.php
+++ b/library/Controller/Purpose/Event.php
@@ -42,13 +42,14 @@ class Event extends PurposeFactory
         // Event dates
         $startDate = '';
         $endDate = '';
+
         if (isset($eventMeta['occasions_complete']) && is_array($eventMeta['occasions_complete'])) {
             $occasions = maybe_unserialize($eventMeta['occasions_complete'][0]);
-            if (isset($occasions['start_date'])) {
-                $startDate = $occasions['start_date'];
+            if (isset($occasions[0]['start_date'])) {
+                $startDate = $occasions[0]['start_date'];
             }
-            if (isset($occasions['end_date'])) {
-                $endDate = $occasions['end_date'];
+            if (isset($occasions[0]['end_date'])) {
+                $endDate = $occasions[0]['end_date'];
             }
         }
 
@@ -68,29 +69,35 @@ class Event extends PurposeFactory
 
         // Event tickets
         if (isset($eventMeta['booking_link']) && isset($eventMeta['booking_link'][0])) {
-            $eventData['offers'] = [
-            '@type' => 'Offer',
-            'name'  => 'ticket',
-            'url'   => $eventMeta['booking_link'][0],
-            ];
+            array_push($eventData['offers'], [
+                '@type' => 'Offer',
+                'name'  => 'ticket',
+                'url'   => $eventMeta['booking_link'][0],
+            ]);
+        }
+        if (isset($eventMeta['price_adult']) && isset($eventMeta['price_adult'][0])) {
+            array_push($eventData['offers'], [
+                '@type' => 'Offer',
+                'name'  => 'ticket',
+                'price'   => $eventMeta['price_adult'][0],
+                'priceCurrency' => 'SEK',
+            ]);
         }
 
+        // TODO Add any other structures for tickets that may be available on events
         if (isset($eventMeta['additional_ticket_types']) && is_array($eventMeta['additional_ticket_types']) && isset($eventMeta['additional_ticket_types'][0])) {
-            $additionalTypes = [];
             $ticketTypes = maybe_unserialize($eventMeta['additional_ticket_types'][0]);
             foreach ($ticketTypes as $type) {
                 if (isset($type['ticket_name']) && isset($type['maximum_price'])) {
-                    $additionalTypes[] = [
-                    '@type'         => 'Offer',
-                    'name'          => $type['ticket_name'],
-                    'price'         => $type['maximum_price'],
-                    'priceCurrency' => 'SEK',
-                    ];
+                    array_push($eventData['offers'], [
+                        '@type'         => 'Offer',
+                        'name'          => $type['ticket_name'],
+                        'price'         => $type['maximum_price'],
+                        'priceCurrency' => 'SEK',
+                    ]);
                 }
             }
-            $eventData['offers'] = array_merge($eventData['offers'], $additionalTypes);
         }
-
         // Append the event data to the structured data
         return array_merge($eventData, $structuredData);
     }

--- a/library/Controller/Purpose/Event.php
+++ b/library/Controller/Purpose/Event.php
@@ -10,6 +10,9 @@ class Event extends PurposeFactory
 {
     public function __construct()
     {
-        parent::__construct('event', __('Event', 'municipio'), ['place' => Place::class]);
+        $this->key = 'event';
+        $this->label = __('Event', 'municipio');
+
+        parent::__construct($this->key, $this->label, ['place' => Place::class]);
     }
 }

--- a/library/Controller/Purpose/Event.php
+++ b/library/Controller/Purpose/Event.php
@@ -63,7 +63,7 @@ class Event extends PurposeFactory
             'startDate'   => $startDate,
             'endDate'     => $endDate,
             'description' => get_the_excerpt($postId),
-            'image'       => $imageUrl,
+            'image'       => [$imageUrl],
             'offers'      => [],
         ];
 

--- a/library/Controller/Purpose/Place.php
+++ b/library/Controller/Purpose/Place.php
@@ -10,7 +10,10 @@ class Place extends PurposeFactory
 {
     public function __construct()
     {
-        parent::__construct('place', __('Place', 'municipio'));
+        $this->key = 'place';
+        $this->label = __('Place', 'municipio');
+
+        parent::__construct($this->key, $this->label);
     }
     public function init(): void
     {

--- a/library/Controller/Purpose/Place.php
+++ b/library/Controller/Purpose/Place.php
@@ -29,35 +29,49 @@ class Place extends PurposeFactory
     *
     * @return array The modified structured data array.
     */
+   /**
+ * Appends location data to structured data.
+ *
+ * @param array $structuredData The structured data to append location data to.
+ * @param string $postType The post type of the post.
+ * @param int $postId The ID of the post to retrieve location data for.
+ * @return array The updated structured data.
+ */
     public function appendStructuredData(array $structuredData, string $postType, int $postId): array
     {
         if (empty($postId)) {
             return $structuredData;
         }
 
-        $additionalData = [];
+        $locationMetaKeys = ['map', 'location'];
+        $additionalData = ['location' => []];
 
-        $location = (array) get_post_meta($postId, 'map', true);
+        foreach ($locationMetaKeys as $key) {
+            $location = get_post_meta($postId, $key, true);
 
-        if (!empty($location['address'])) {
-            $additionalData['location'][] = [
-               '@type'   => 'Place',
-               'address' => $location['address'],
-            ];
+            if (!empty($location['address'])) {
+                $additionalData['location'][] = [
+                '@type'   => 'Place',
+                'address' => $location['address'],
+                ];
+            }
+
+            if (!empty($location['lat']) && !empty($location['lng'])) {
+                $additionalData['location'][] = [
+                '@type'     => 'GeoCoordinates',
+                'latitude'  => $location['lat'],
+                'longitude' => $location['lng'],
+                ];
+            }
+
+            if (!empty($location['country'])) {
+                $additionalData['location'][] = [
+                '@type'          => 'PostalAddress',
+                'addressCountry' => $location['country'],
+                ];
+            }
         }
-        if (!empty($location['lat']) && !empty($location['lng'])) {
-            $additionalData['location'][] = [
-               '@type'     => 'GeoCoordinates',
-               'latitude'  => $location['lat'],
-               'longitude' => $location['lng'],
-            ];
-        }
-        if (!empty($location['country'])) {
-            $additionalData['location'][] = [
-               '@type'     => 'PostalAddess',
-               'country'  => $location['country'],
-            ];
-        }
+
         return array_merge($structuredData, $additionalData);
     }
 }

--- a/library/Controller/Purpose/Place.php
+++ b/library/Controller/Purpose/Place.php
@@ -43,31 +43,42 @@ class Place extends PurposeFactory
             return $structuredData;
         }
 
-        $locationMetaKeys = ['map', 'location'];
+        $locationMetaKeys = ['map', 'location']; // Post meta keys we'l check for location data.
         $additionalData = ['location' => []];
 
         foreach ($locationMetaKeys as $key) {
             $location = get_post_meta($postId, $key, true);
+            if (empty($location)) {
+                continue;
+            }
 
-            if (!empty($location['address'])) {
+            // General address
+            if (!empty($location['formatted_address'])) {
                 $additionalData['location'][] = [
-                '@type'   => 'Place',
-                'address' => $location['address'],
+                    '@type'   => 'Place',
+                    'address' => $location['formatted_address'],
+                ];
+            } elseif (!empty($location['address'])) {
+                $additionalData['location'][] = [
+                    '@type'   => 'Place',
+                    'address' => $location['address'],
                 ];
             }
 
+            // Coordinates
             if (!empty($location['lat']) && !empty($location['lng'])) {
                 $additionalData['location'][] = [
-                '@type'     => 'GeoCoordinates',
-                'latitude'  => $location['lat'],
-                'longitude' => $location['lng'],
+                    '@type'     => 'GeoCoordinates',
+                    'latitude'  => $location['lat'],
+                    'longitude' => $location['lng'],
                 ];
             }
 
+            // Country
             if (!empty($location['country'])) {
                 $additionalData['location'][] = [
-                '@type'          => 'PostalAddress',
-                'addressCountry' => $location['country'],
+                    '@type'          => 'PostalAddress',
+                    'addressCountry' => $location['country'],
                 ];
             }
         }

--- a/library/Controller/Purpose/Place.php
+++ b/library/Controller/Purpose/Place.php
@@ -23,20 +23,13 @@ class Place extends PurposeFactory
     /**
     * Appends the structured data array (used for schema.org markup) with additional data
     *
-    * @param array structuredData The structured data array that we're going to append to.
-    * @param string postType The post type of the current page.
-    * @param int postId The ID of the post you want to add structured data to.
+    * @param array $structuredData The structured data to append location data to.
+    * @param string $postType The post type of the post.
+    * @param int $postId The ID of the post to retrieve location data for.
     *
-    * @return array The modified structured data array.
+    * @return array The updated structured data.
+    *
     */
-   /**
- * Appends location data to structured data.
- *
- * @param array $structuredData The structured data to append location data to.
- * @param string $postType The post type of the post.
- * @param int $postId The ID of the post to retrieve location data for.
- * @return array The updated structured data.
- */
     public function appendStructuredData(array $structuredData, string $postType, int $postId): array
     {
         if (empty($postId)) {

--- a/library/Controller/Purpose/Project.php
+++ b/library/Controller/Purpose/Project.php
@@ -10,7 +10,10 @@ class Project extends PurposeFactory
 {
     public function __construct()
     {
-        parent::__construct('project', __('Project', 'municipio'), ['place' => Place::class]);
+        $this->key = 'project';
+        $this->label = __('Project', 'municipio');
+
+        parent::__construct($this->key, $this->label, ['place' => Place::class]);
     }
 
     public function init(): void

--- a/library/Controller/Purpose/PurposeFactory.php
+++ b/library/Controller/Purpose/PurposeFactory.php
@@ -16,8 +16,6 @@ class PurposeFactory
         $this->secondaryPurpose = $secondaryPurpose;
         $this->view             = "purpose-{$key}";
 
-        $this->init();
-
         self::initSecondaryPurposes();
     }
     /**

--- a/library/Controller/Purpose/PurposeFactory.php
+++ b/library/Controller/Purpose/PurposeFactory.php
@@ -4,9 +4,9 @@ namespace Municipio\Controller\Purpose;
 
 class PurposeFactory
 {
-    protected string $key;
-    protected string $label;
-    protected array $secondaryPurpose;
+    public string $key;
+    public string $label;
+    public array $secondaryPurpose;
     protected string $view;
 
     public function __construct(string $key, string $label, array $secondaryPurpose = [])

--- a/library/Controller/Purpose/PurposeFactory.php
+++ b/library/Controller/Purpose/PurposeFactory.php
@@ -18,7 +18,7 @@ class PurposeFactory
 
         $this->init();
 
-        self::registerSecondaryPurposes();
+        self::initSecondaryPurposes();
     }
     /**
      * This method is empty by default and can be overridden by subclasses to add their own initialization logic.
@@ -27,7 +27,7 @@ class PurposeFactory
     {
     }
 
-    protected function registerSecondaryPurposes()
+    protected function initSecondaryPurposes()
     {
         if (!empty($this->getSecondaryPurpose())) {
             foreach ($this->getSecondaryPurpose() as $className) {

--- a/library/Controller/SingularPurpose.php
+++ b/library/Controller/SingularPurpose.php
@@ -21,9 +21,11 @@ class SingularPurpose extends \Municipio\Controller\Singular
         /**
          * Setup current purpose
          */
-        $currentPurpose = PurposeHelper::getPurpose($type);
-        if (isset($currentPurpose['main']) && !PurposeHelper::skipPurposeTemplate($type)) {
-            $this->view = $currentPurpose['main']->getView();
+        $purpose = PurposeHelper::getPurpose($type);
+        $instance = PurposeHelper::getPurposeInstance($purpose, true);
+
+        if (!PurposeHelper::skipPurposeTemplate($type)) {
+            $this->view = $instance->getView();
         }
 
 

--- a/library/Controller/SingularPurpose.php
+++ b/library/Controller/SingularPurpose.php
@@ -21,7 +21,7 @@ class SingularPurpose extends \Municipio\Controller\Singular
         /**
          * Setup current purpose
          */
-        $currentPurpose = PurposeHelper::getPurposes($type);
+        $currentPurpose = PurposeHelper::getPurpose($type);
         if (isset($currentPurpose['main']) && !PurposeHelper::skipPurposeTemplate($type)) {
             $this->view = $currentPurpose['main']->getView();
         }

--- a/library/Controller/SingularPurpose.php
+++ b/library/Controller/SingularPurpose.php
@@ -19,15 +19,17 @@ class SingularPurpose extends \Municipio\Controller\Singular
         $type = $this->data['post']->postType;
 
         /**
-         * Setup current purpose
+         * Instantiate the current main purpose
          */
         $purpose = PurposeHelper::getPurpose($type);
-        $instance = PurposeHelper::getPurposeInstance($purpose, true);
-
-        if (!PurposeHelper::skipPurposeTemplate($type)) {
-            $this->view = $instance->getView();
+        if (!empty($purpose)) {
+            // Run initialisation on the main purpose
+            $instance = PurposeHelper::getPurposeInstance($purpose[0], true);
+            // Set view if allowed
+            if (!PurposeHelper::skipPurposeTemplate($type)) {
+                $this->view = $instance->getView();
+            }
         }
-
 
         // STRUCTURED DATA (SCHEMA.ORG)
         $this->data['structuredData'] = DataHelper::getStructuredData(

--- a/library/Helper/Purpose.php
+++ b/library/Helper/Purpose.php
@@ -57,16 +57,37 @@ class Purpose
  *
  * @return string The purpose as a string. Retruns an empty string if no purpose is found.
  */
-    public static function getPurpose(string $type = ''): string
+    public static function getPurpose(string $type = '', bool $includeSecondary = false): array
     {
         if ('' === $type) {
             $type = self::getCurrentType();
         }
 
-        $purpose = get_option("options_purpose_{$type}", '');
+        $purpose = [];
+        $purposeStr = get_option("options_purpose_{$type}", '');
+
+        if ('' !== $purposeStr) {
+            $instance = self::getPurposeInstance($purposeStr);
+            $purpose[] = $instance;
+
+            if ($includeSecondary && !empty($instance->secondaryPurpose)) {
+                foreach ($instance->secondaryPurpose as $key => $className) {
+                    $secondaryInstance = self::getPurposeInstance($key, false);
+                    $purpose[] = $secondaryInstance;
+                }
+            }
+        }
 
         return apply_filters('Municipio/Purpose/getPurpose', $purpose, $type);
     }
+    /**
+     * > Get the instance of a registered purpose
+     *
+     * @param string purpose The purpose you want to get the instance of.
+     * @param bool init If true, the purpose will be initialized via it's init() method.
+     *
+     * @return The class instance of the purpose.
+     */
     public static function getPurposeInstance(string $purpose, bool $init = false)
     {
         $registeredPurposes = self::getRegisteredPurposes(true);
@@ -80,14 +101,19 @@ class Purpose
 
         return false;
     }
+
     /**
-     * Alias for getPurpose
+     * It checks if the purpose is empty or not.
      *
-     * @return string The return value of the function getPurpose()
+     * @param string type The type of the purpose.
      */
-    public static function hasPurpose(): string
+    public static function hasPurpose(string $type = ''): bool
     {
-        return self::getPurpose();
+        $purpose = self::getPurpose();
+        if (!empty($purpose)) {
+            return true;
+        }
+        return false;
     }
     /**
      * Get the current type.

--- a/library/Helper/Purpose.php
+++ b/library/Helper/Purpose.php
@@ -55,38 +55,21 @@ class Purpose
  *
  * @param string $type The type of data to get the purpose for. This can be a post type or taxonomy.
  *
- * @return string|false The purpose as a string or false if the purpose does not exist.
+ * @return string The purpose as a string. Retruns an empty string if no purpose is found.
  */
-    public static function getPurpose(string $type = '')
+    public static function getPurpose(string $type = ''): string
     {
         if ('' === $type) {
             $type = self::getCurrentType();
         }
 
-        $purpose = self::getPurposeString($type);
-        if (!$purpose) {
-            return false;
-        }
+        $purpose = get_option("options_purpose_{$type}", '');
 
-        return apply_filters('Municipio/Purpose/getPurpose', $purpose, $type, $current);
+        return apply_filters('Municipio/Purpose/getPurpose', $purpose, $type);
     }
     public static function hasPurpose(): string
     {
         return self::getPurpose();
-    }
-
-
-    private static function getPurposeString(string $type)
-    {
-        $mainPurposeKey = get_option("options_purposes_{$type}", false);
-        if (!$mainPurposeKey) {
-            return false;
-        }
-
-        $registeredPurposes = self::getRegisteredPurposes(true);
-        $mainPurpose = $registeredPurposes[$mainPurposeKey]['class'] ?? null;
-
-        return $mainPurpose;
     }
 
     private static function getCurrentType(string $current = ''): string

--- a/library/Helper/Purpose.php
+++ b/library/Helper/Purpose.php
@@ -36,9 +36,9 @@ class Purpose
 
                     if ($includeExtras) {
                         $purposes[$instance->getKey()] = [
-                        'class'     => $instance,
-                        'className' => $classNameWithNamespace,
-                        'path'      => $filename
+                            'class'     => $instance,
+                            'className' => $classNameWithNamespace,
+                            'path'      => $filename
                         ];
                     } else {
                         $purposes[$instance->getKey()] = $instance->getLabel();
@@ -66,6 +66,19 @@ class Purpose
         $purpose = get_option("options_purpose_{$type}", '');
 
         return apply_filters('Municipio/Purpose/getPurpose', $purpose, $type);
+    }
+    public static function getPurposeInstance(string $purpose, bool $init = false)
+    {
+        $registeredPurposes = self::getRegisteredPurposes(true);
+        if (isset($registeredPurposes[$purpose]) && isset($registeredPurposes[$purpose]['class'])) {
+            $instance = $registeredPurposes[$purpose]['class'];
+            if (true === $init) {
+                $instance->init();
+            }
+            return $instance;
+        }
+
+        return false;
     }
     /**
      * Alias for getPurpose

--- a/library/Helper/Purpose.php
+++ b/library/Helper/Purpose.php
@@ -66,18 +66,8 @@ class Purpose
  */
     public static function getPurpose(string $type = '')
     {
-        $current = get_queried_object();
-
-        if ('' === $type && !$current) {
-            return false;
-        }
-
-        if ('' === $type && is_a($current, 'WP_Post_Type')) {
-            $type = $current->name;
-        } elseif ('' === $type && is_a($current, 'WP_Post')) {
-            $type = $current->post_type;
-        } elseif ('' === $type && is_a($current, 'WP_Term')) {
-            $type = $current->taxonomy;
+        if ('' === $type) {
+            $type = self::getCurrentType();
         }
 
         $purpose = self::getPurposeString($type);
@@ -87,6 +77,11 @@ class Purpose
 
         return apply_filters('Municipio/Purpose/getPurpose', $purpose, $type, $current);
     }
+    public static function hasPurpose(): string
+    {
+        return self::getPurpose();
+    }
+
 
     private static function getPurposeString(string $type)
     {
@@ -101,25 +96,10 @@ class Purpose
         return $mainPurpose;
     }
 
-    public static function hasPurpose(string $type = ''): string
+    private static function getCurrentType(string $current = ''): string
     {
-        if ('' === $type) {
+        if ('' === $current) {
             $current = get_queried_object();
-            $type = self::getCurrentType($current);
-            if (!$type) {
-                return '';
-            }
-        }
-
-        $purpose = self::getPurpose($type);
-
-        return $purpose ?: '';
-    }
-
-    private static function getCurrentType($current): ?string
-    {
-        if (!$current) {
-            return null;
         }
 
         if (is_a($current, 'WP_Post_Type')) {
@@ -128,6 +108,8 @@ class Purpose
             $type = $current->post_type;
         } elseif (is_a($current, 'WP_Term')) {
             $type = $current->taxonomy;
+        } else {
+            return '';
         }
 
         return $type;

--- a/library/Helper/Purpose.php
+++ b/library/Helper/Purpose.php
@@ -25,13 +25,16 @@ class Purpose
                     $className = basename($filename, '.php');
                     $classNameWithNamespace = $namespace . '\\' . $className;
 
+                    $instance = new $classNameWithNamespace();
+
                     if ($includeExtras) {
-                        $purposes[$className] = [
-                            'class' => $classNameWithNamespace,
-                            'path' => $filename
+                        $purposes[$instance->getKey()] = [
+                            'class'     => $instance,
+                            'className' => $classNameWithNamespace,
+                            'path'      => $filename
                         ];
                     } else {
-                        $purposes[strtolower($className)] = $className;
+                        $purposes[$instance->getKey()] = $instance->getLabel();
                     }
                 }
             }
@@ -73,25 +76,18 @@ class Purpose
 
     private static function getPurposesArray(string $type)
     {
-        $mainPurpose = ucfirst(get_option("options_purposes_{$type}", false));
-        if (!$mainPurpose) {
+        $mainPurposeKey = get_option("options_purposes_{$type}", false);
+        if (!$mainPurposeKey) {
             return false;
         }
 
         $purposes = [];
         $registeredPurposes = self::getRegisteredPurposes(true);
-        $mainPurposeClass = $registeredPurposes[$mainPurpose]['class'] ?? null;
-
-        if (!$mainPurposeClass || !class_exists($mainPurposeClass)) {
-            return false;
-        }
-
-        // Instantiate the main purpose
-        $instance = new $mainPurposeClass();
-        $purposes['main'] = $instance;
+        $mainPurpose = $registeredPurposes[$mainPurposeKey]['class'] ?? null;
+        $purposes['main'] = $mainPurpose;
 
         // Instantiate secondary purposes
-        $secondaryPurpose = $instance->getSecondaryPurpose();
+        $secondaryPurpose = $mainPurpose->getSecondaryPurpose();
         if (!empty($secondaryPurpose)) {
             foreach ($secondaryPurpose as $key => $value) {
                 $class = $registeredPurposes[$key]['class'] ?? null;

--- a/library/Helper/Purpose.php
+++ b/library/Helper/Purpose.php
@@ -67,11 +67,22 @@ class Purpose
 
         return apply_filters('Municipio/Purpose/getPurpose', $purpose, $type);
     }
+    /**
+     * Alias for getPurpose
+     *
+     * @return string The return value of the function getPurpose()
+     */
     public static function hasPurpose(): string
     {
         return self::getPurpose();
     }
-
+    /**
+     * Get the current type.
+     *
+     * @param string $current The current type.
+     *
+     * @return string The current type.
+     */
     private static function getCurrentType(string $current = ''): string
     {
         if ('' === $current) {

--- a/library/Helper/Purpose.php
+++ b/library/Helper/Purpose.php
@@ -31,7 +31,7 @@ class Purpose
                             'path' => $filename
                         ];
                     } else {
-                        $purposes[$className] = $classNameWithNamespace;
+                        $purposes[strtolower($className)] = $className;
                     }
                 }
             }

--- a/library/Theme/General.php
+++ b/library/Theme/General.php
@@ -9,6 +9,7 @@ class General
         add_action('init', array($this, 'bemItClassDefinition'));
 
         add_filter('body_class', array($this, 'appendBEMITCssClass'));
+        add_filter('body_class', array($this, 'appendPurposeCssClass'));
         add_filter('body_class', array($this, 'isChildTheme'));
         add_filter('body_class', array($this, 'e404classes'));
 
@@ -232,6 +233,20 @@ class General
     {
         if (defined('MUNICIPIO_BEM_THEME_NAME')) {
             $classes[] = MUNICIPIO_BEM_THEME_NAME;
+        }
+        return $classes;
+    }
+    /**
+     * If the current page has a purpose, add a class to the body tag
+     *
+     * @param classes The array of classes to be appended to.
+     *
+     * @return the  array with the new class added.
+     */
+    public function appendPurposeCssClass($classes)
+    {
+        if ($purpose = \Municipio\Helper\Purpose::hasPurpose()) {
+            $classes[] = "purpose-$purpose";
         }
         return $classes;
     }

--- a/library/Theme/General.php
+++ b/library/Theme/General.php
@@ -237,16 +237,22 @@ class General
         return $classes;
     }
     /**
-     * If the current page has a purpose, add a class to the body tag
+     * It adds a CSS class to the body tag for each purpose that is set in the admin
      *
      * @param classes The array of classes to be appended to.
      *
-     * @return the  array with the new class added.
+     * @return An array of classes.
      */
+
     public function appendPurposeCssClass($classes)
     {
-        if ($purpose = \Municipio\Helper\Purpose::hasPurpose()) {
-            $classes[] = "purpose-$purpose";
+        if ($purposes = \Municipio\Helper\Purpose::getPurpose()) {
+            foreach ($purposes as $key => $purpose) {
+                $classes[] = "purpose-$purpose";
+                if (0 === $key) {
+                    $classes[] = "primary-purpose-{$purpose}";
+                }
+            }
         }
         return $classes;
     }


### PR DESCRIPTION
- `Added` Structured data for schema.org markup for purpose event
- `Added` Add purpose class in body_class
- `Fixed` Fixed incorrect parameter name when looking for current screen in admin
- `Fixed` Changed when the init method is run so that it doesn't run the add_filters for all purposes all of the time; instead just the actual purpose added to the current content type is initiated.
- `Change` Cleaned up and simplified the purpose helper methods
- `Change` ACF location rule for purposes also matches on secondary purposes  