### PR TITLE
Await post types before registering customizer panels

### DIFF
--- a/library/Customizer.php
+++ b/library/Customizer.php
@@ -30,7 +30,7 @@ class Customizer
                     'link_text' => __("Install plugin", 'municipio')
                 ]
             );
-        }, 10);
+        }, 11);
 
         /**
          * Fixes issue when using :root selector in


### PR DESCRIPTION
Fixes issue with missing post types under the Archives panel in the customizer.