### PR TITLE
Fix: Customizer not saving

### DIFF
--- a/assets/source/3.0/js/admin/widgetsAreaHider.js
+++ b/assets/source/3.0/js/admin/widgetsAreaHider.js
@@ -34,5 +34,9 @@ document.addEventListener("DOMContentLoaded", function() {
   };
 
   const observer = new MutationObserver(callback);
-  observer.observe(document.querySelector("#widgets-editor"), config);
+  const widgetsEditor = document.querySelector("#widgets-editor");
+  if (widgetsEditor !== null) {
+    observer.observe(widgetsEditor, config);
+  }
+  
 });

--- a/library/Customizer/Sections/Archive.php
+++ b/library/Customizer/Sections/Archive.php
@@ -158,6 +158,7 @@ class Archive
             'section'     => $sectionID,
             // Below prevents Kirki bugg from using faulty default sanitize_callback.
             'sanitize_callback' => fn($values) => $values,
+            'default' => [],
             'choices'     => array_merge(
                 [
                     'text_search' => esc_html__('Text search', 'municipio'),

--- a/library/Theme/Enqueue.Test.php
+++ b/library/Theme/Enqueue.Test.php
@@ -1,0 +1,66 @@
+<?php
+
+class EnqueueTest extends \PHPUnit\Framework\TestCase
+{
+    public function testIsDefined()
+    {
+        $this->assertTrue(class_exists('Municipio\Theme\Enqueue'));
+    }
+
+    public function testGetScriptDependenciesReturnsArrayOfStrings()
+    {
+        global $wp_scripts;
+        $wp_scripts->registered = $this->buildRegisteredScriptsObject(['foo' => []]);
+        $enqueue = new Municipio\Theme\Enqueue();
+        $scripts = $enqueue->getScriptDependencies('foo');
+        $this->assertIsArray($scripts);
+        $this->assertContainsOnly('string', $scripts);
+    }
+
+    public function testGetScriptDependenciesIncludesScriptDependencies()
+    {
+        $wp_scripts = new stdClass();
+        global $wp_scripts;
+        $wp_scripts->registered = $this->buildRegisteredScriptsObject(['wp-i18n' => ['jquery']]);
+        $enqueue = new Municipio\Theme\Enqueue();
+        $handles = $enqueue->getScriptDependencies('wp-i18n');
+        $this->assertContains('jquery', $handles);
+    }
+
+    public function testGetScriptDependenciesCallsThrowsIfScriptIsNotRegistered() {
+        $wp_scripts = new stdClass();
+        global $wp_scripts;
+        $wp_scripts->registered = [];
+        $enqueue = new Municipio\Theme\Enqueue();
+
+        try {
+            $enqueue->getScriptDependencies('foo', true);
+        } catch (Exception $e) {
+            $this->assertEquals('Script "foo" is not registered.', $e->getMessage());
+            return;
+        }
+    }
+
+    public function testGetScriptDependenciesIncludesScriptDependenciesMultipleLevelsUp()
+    {
+        $wp_scripts = new stdClass();
+        global $wp_scripts;
+        $wp_scripts->registered = $this->buildRegisteredScriptsObject(['wp-i18n' => ['jquery'], 'jquery' => ['jquery-core']]);
+        $enqueue = new Municipio\Theme\Enqueue();
+        $handles = $enqueue->getScriptDependencies('wp-i18n');
+        $this->assertContains('jquery-core', $handles);
+    }
+
+    private function buildRegisteredScriptsObject(array $scripts)
+    {
+        $registered = [];
+
+        foreach ($scripts as $handle => $deps) {
+            $registered[$handle] = (object) [
+                'deps' => $deps,
+            ];
+        }
+
+        return $registered;
+    }
+}


### PR DESCRIPTION
* Incorrectly enqueued scripts caused Error "wp is not defined".
* When using Kirki active_callback and depending on a Kirki multi select field the default value of the dependency field cannot be an empty string. Solved by using an empty array.
* Handle possibly missing element throwing in widgetAreaHider.