### PR TITLE
fix: invalid parameters passed to implode

### DIFF
--- a/library/Admin/General.php
+++ b/library/Admin/General.php
@@ -52,10 +52,11 @@ class General
     {
         $palettesToGet = ['color_palette_primary','color_palette_secondary'];
         $colorPalettes = \Municipio\Helper\Color::getPalettes($palettesToGet);
+        $colorPalettesSanitized = array_filter($colorPalettes, fn ($value) => is_array($value) && !empty($value));
 
-        if (!empty($colorPalettes)) {
+        if (!empty($colorPalettesSanitized)) {
             $colorsStr = '';
-            foreach ($colorPalettes as $colors) {
+            foreach ($colorPalettesSanitized as $colors) {
                 $colorsStr .= '"' . implode('","', $colors) . '",';
             }
             echo "


### PR DESCRIPTION
Fixes unhandled warning when passing strings to implodes 2nd parameter.