### PR TITLE
fix: Could not navigate drawer menu with keyboard

### DIFF
--- a/views/v3/partials/navigation/drawer.blade.php
+++ b/views/v3/partials/navigation/drawer.blade.php
@@ -17,7 +17,7 @@
         ]
     ],
     'id' => 'drawer',
-    'attributeList' => ['data-move-to' => 'body', 'data-js-toggle-item' => 'drawer'],
+    'attributeList' => ['data-js-toggle-item' => 'drawer'],
     'classList' => [
         'c-drawer--' . (!empty($mobileMenuItems)&&!empty($mobileMenuSecondaryItems) ? 'duotone' : 'monotone'),
         's-drawer-menu'


### PR DESCRIPTION
Although navigating the drawer menu is possible via keyboard, the fact that it's moved to the end of `<body>` places it at the end in the page’s tab order which is unpredictable and impractical. I am not sure why it is intentionally moved to the end via JS, but everything seems to be working fine if it is not moved.