### PR TITLE
fix: implement the runtime cache on preparePost functions.

### DIFF
--- a/library/Helper/Post.php
+++ b/library/Helper/Post.php
@@ -29,7 +29,7 @@ class Post
     public static function preparePostObject(\WP_Post $post, $data = null): object
     {
         // Create a unique cache key based on the post ID and serialized data
-        $cacheKey = $post->ID . '_' . serialize($data);
+        $cacheKey = md5($post->ID . '_' . serialize($data));
 
         if (!isset(self::$runtimeCache['preparePostObject'])) {
             self::$runtimeCache['preparePostObject'] = [];
@@ -84,7 +84,7 @@ class Post
      */
     public static function preparePostObjectArchive(\WP_Post $post, $data = null): object
     {
-        $cacheKey = $post->ID . '_' . serialize($data);
+        $cacheKey = md5($post->ID . '_' . serialize($data));
 
         if (!isset(self::$runtimeCache['preparePostObjectArchive'])) {
             self::$runtimeCache['preparePostObjectArchive'] = [];
@@ -93,7 +93,7 @@ class Post
         if (isset(self::$runtimeCache['preparePostObjectArchive'][$cacheKey])) {
             return self::$runtimeCache['preparePostObjectArchive'][$cacheKey];
         }
-        
+
         $post = self::complementObject(
             $post,
             [

--- a/library/Helper/Post.php
+++ b/library/Helper/Post.php
@@ -28,24 +28,38 @@ class Post
      */
     public static function preparePostObject(\WP_Post $post, $data = null): object
     {
+        // Create a unique cache key based on the post ID and serialized data
+        $cacheKey = $post->ID . '_' . serialize($data);
+
+        if (!isset(self::$runtimeCache['preparePostObject'])) {
+            self::$runtimeCache['preparePostObject'] = [];
+        }
+
+        if (isset(self::$runtimeCache['preparePostObject'][$cacheKey])) {
+            return self::$runtimeCache['preparePostObject'][$cacheKey];
+        }
+
+        // Perform the original operations
         $post = self::complementObject(
             $post,
             [
-            'excerpt',
-            'post_content_filtered',
-            'post_title_filtered',
-            'permalink',
-            'terms',
-            'post_language',
-            'reading_time',
-            'quicklinks',
-            'call_to_action_items',
-            'term_icon'
+                'excerpt',
+                'post_content_filtered',
+                'post_title_filtered',
+                'permalink',
+                'terms',
+                'post_language',
+                'reading_time',
+                'quicklinks',
+                'call_to_action_items',
+                'term_icon'
             ],
             $data
         );
 
-        return \Municipio\Helper\FormatObject::camelCase($post);
+        return self::$runtimeCache['preparePostObject'][$cacheKey] = \Municipio\Helper\FormatObject::camelCase(
+            $post
+        );
     }
 
      /**
@@ -70,6 +84,16 @@ class Post
      */
     public static function preparePostObjectArchive(\WP_Post $post, $data = null): object
     {
+        $cacheKey = $post->ID . '_' . serialize($data);
+
+        if (!isset(self::$runtimeCache['preparePostObjectArchive'])) {
+            self::$runtimeCache['preparePostObjectArchive'] = [];
+        }
+
+        if (isset(self::$runtimeCache['preparePostObjectArchive'][$cacheKey])) {
+            return self::$runtimeCache['preparePostObjectArchive'][$cacheKey];
+        }
+        
         $post = self::complementObject(
             $post,
             [
@@ -84,7 +108,9 @@ class Post
             $data
         );
 
-        return \Municipio\Helper\FormatObject::camelCase($post);
+        return self::$runtimeCache['preparePostObjectArchive'][$cacheKey] = \Municipio\Helper\FormatObject::camelCase(
+            $post
+        );
     }
 
     /**


### PR DESCRIPTION
This fix, intends to improve performance by blocking and returning already knows results from runtime cache whenever a intentical request is made towards preparePostObject functions. 

<img width="667" alt="Skärmavbild 2024-06-13 kl  22 36 01" src="https://github.com/helsingborg-stad/Municipio/assets/797129/6b6c35f3-3120-457f-bc6a-10daf7763956">
