### PR TITLE
fix: Posts with same ID are overwritten in preparePostObjectCache

### DIFF
--- a/library/Helper/Post.php
+++ b/library/Helper/Post.php
@@ -15,7 +15,7 @@ use WP_Post;
 class Post
 {
     //Stores cache in runtime
-    private static $runtimeCache = [];
+    public static $runtimeCache = [];
 
     /**
      * Prepare post object before sending to view
@@ -29,7 +29,7 @@ class Post
     public static function preparePostObject(\WP_Post $post, $data = null): object
     {
         // Create a unique cache key based on the post ID and serialized data
-        $cacheKey = md5($post->ID . '_' . serialize($data));
+        $cacheKey = md5($post->ID . $post->post_date . '_' . serialize($data));
 
         if (!isset(self::$runtimeCache['preparePostObject'])) {
             self::$runtimeCache['preparePostObject'] = [];

--- a/library/Helper/Post.php
+++ b/library/Helper/Post.php
@@ -29,7 +29,8 @@ class Post
     public static function preparePostObject(\WP_Post $post, $data = null): object
     {
         // Create a unique cache key based on the post ID and serialized data
-        $cacheKey = md5($post->ID . $post->post_date . '_' . serialize($data));
+        $serializedPost = serialize($post);
+        $cacheKey = md5($serializedPost . '_' . serialize($data));
 
         if (!isset(self::$runtimeCache['preparePostObject'])) {
             self::$runtimeCache['preparePostObject'] = [];

--- a/library/Helper/Post.php
+++ b/library/Helper/Post.php
@@ -29,7 +29,7 @@ class Post
     public static function preparePostObject(\WP_Post $post, $data = null): object
     {
         // Create a unique cache key based on the post ID and serialized data
-        $serializedPost = serialize($post);
+        $serializedPost = serialize(get_object_vars($post));
         $cacheKey = md5($serializedPost . '_' . serialize($data));
 
         if (!isset(self::$runtimeCache['preparePostObject'])) {

--- a/tests/phpunit/tests/Helper/Post.php
+++ b/tests/phpunit/tests/Helper/Post.php
@@ -29,6 +29,25 @@ class PostTest extends TestCase
         // Then
         $this->assertIsObject($result);
     }
+    
+    /**
+     * @testdox preparePostObject: runtimeCache can add multiple posts with the same ID by also using post_date as a key.
+    */
+    public function testPreparePostObjectCanAddMultiplePostsToRuntimeCacheUsingSameID()
+    {
+        // Given
+        $post1 = $this->mockPost(['ID' => 1, 'post_date' => '2021-01-02 00:00:00']);
+        $post2 = $this->mockPost(['ID' => 1, 'post_date' => '2021-01-01 00:00:00']);
+        $mock = $this->mockStaticMethod('\Municipio\Helper\Post', 'complementObject');
+        $mock->andReturnUsing(fn ($post) => $post);
+
+        // When
+        \Municipio\Helper\Post::preparePostObject($post1);
+        \Municipio\Helper\Post::preparePostObject($post2);
+
+        // Then
+        $this->assertCount(2, \Municipio\Helper\Post::$runtimeCache['preparePostObject']);
+    }
 
      /**
      * @testdox preparePostObjectArchive returns a post if it $post is an instance of WP_Post.

--- a/tests/phpunit/tests/Helper/Post.php
+++ b/tests/phpunit/tests/Helper/Post.php
@@ -31,7 +31,7 @@ class PostTest extends TestCase
     }
     
     /**
-     * @testdox preparePostObject: runtimeCache can add multiple posts with the same ID by also using post_date as a key.
+     * @testdox preparePostObject: runtimeCache can add multiple posts with the same ID.
     */
     public function testPreparePostObjectCanAddMultiplePostsToRuntimeCacheUsingSameID()
     {


### PR DESCRIPTION
When multiple posts have the same ID they are overwritten in the preparePostObject cache. To avoid this conflict the post_date is also used to make the cache key unique.