### PR TITLE
Chore/refactor applicators

### DIFF
--- a/library/Customizer/Applicators/AbstractApplicator.php
+++ b/library/Customizer/Applicators/AbstractApplicator.php
@@ -7,8 +7,6 @@ use Kirki\Util\Helper as KirkiHelper;
 
 abstract class AbstractApplicator
 {
-    private static $contextCache = [];
-
     /**
      * Get fields.
      * 
@@ -131,42 +129,5 @@ abstract class AbstractApplicator
         }
 
         return $output['type'] === $type;
-    }
-
-
-    /** TODO: Refactor, move. */
-    protected function hasFilterContexts(array $contexts, array $filterContexts): bool
-    {
-
-        $cacheKey = md5(serialize($contexts) . serialize($filterContexts));
-
-        if (isset(self::$contextCache[$cacheKey])) {
-            return self::$contextCache[$cacheKey];
-        }
-
-        $hasContext = [];
-        foreach ($filterContexts as $context) {
-
-            // Handle malformed configuration
-            if(is_string($context)) {
-                $context = [
-                    'context' => $context,
-                    'operator' => '=='
-                ];
-                error_log('Malformed context configuration detected. Please update your configuration to match the new format.');
-            }
-
-            // Verify that context is a string and format it for eval
-            if (is_string($context['context'])) {
-                $context['context'] = '"' . $context['context'] . '"';
-            } else {
-                trigger_error("Provided context value in context for modifier is not a string.", E_USER_ERROR);
-            }
-
-            // Check if provided context exists in context array and compare using operator
-            $hasContext[] = (bool) eval('return in_array(' . $context['context'] . ', $contexts) ' . $context['operator'] . ' true;');
-        }
-
-        return (bool) self::$contextCache[$cacheKey] = array_product($hasContext);
     }
 }

--- a/library/Customizer/Applicators/ComponentData.php
+++ b/library/Customizer/Applicators/ComponentData.php
@@ -46,10 +46,10 @@ class ComponentData extends AbstractApplicator
                             add_filter('ComponentLibrary/Component/Data', function ($data) use ($filter) {
 
                                 // Normalize context
-                                $contexts = is_string($data['context']) ? [$data['context']] : $data['context'];
+                                $contexts = !is_array($data['context']) ? [$data['context']] : $data['context'];
 
                                 //Component has no context, do not apply filter
-                                if(!is_array($contexts) || empty($data['context'])) {
+                                if(empty($data['context'])) {
                                     return $data;
                                 }
 

--- a/library/Customizer/Applicators/ComponentData.php
+++ b/library/Customizer/Applicators/ComponentData.php
@@ -53,11 +53,41 @@ class ComponentData extends AbstractApplicator
                                     return $data;
                                 }
 
+                                foreach($filter['contexts'] as $filterContext) {
 
-                                foreach($contexts as $context) {
-                                    if (in_array($context, $filter['contexts'])) {
-                                        echo "match"; 
-                                        $data = array_replace_recursive($data, $filter['data']);
+                                    // Operator and context must be set
+                                    if(!isset($filterContext['operator']) || !isset($filterContext['context'])) {
+                                        continue;
+                                    }
+
+                                    // Operator must be != or ==
+                                    if(!in_array($filterContext['operator'], ["!=","=="])) {
+                                        continue;
+                                    }
+
+                                    // Operator ==
+                                    if (isset($filterContext['context']) && in_array($filterContext['context'], $contexts)) {
+                                        $data = array_replace_recursive(
+                                            $data, 
+                                            $filter['data']
+                                        );
+                                        break;
+                                    }
+
+                                    // Operator !=
+                                    if ($filterContext['operator'] == "==" && !in_array($filterContext['context'], $contexts)) {
+                                        $data = array_replace_recursive(
+                                            $data, 
+                                            $filter['data']
+                                        );
+                                        break;
+                                    }
+
+                                    if ($filterContext['operator'] == "!=" && !in_array($filterContext['context'], $contexts)) {
+                                        $data = array_replace_recursive(
+                                            $data, 
+                                            $filter['data']
+                                        );
                                         break;
                                     }
                                 }

--- a/library/Customizer/Applicators/ComponentData.php
+++ b/library/Customizer/Applicators/ComponentData.php
@@ -66,7 +66,7 @@ class ComponentData extends AbstractApplicator
                                     }
 
                                     // Operator ==
-                                    if (isset($filterContext['context']) && in_array($filterContext['context'], $contexts)) {
+                                    if ($filterContext['operator'] == "==" && in_array($filterContext['context'], $contexts)) {
                                         $data = array_replace_recursive(
                                             $data, 
                                             $filter['data']
@@ -74,15 +74,7 @@ class ComponentData extends AbstractApplicator
                                         break;
                                     }
 
-                                    // Operator !=
-                                    if ($filterContext['operator'] == "==" && !in_array($filterContext['context'], $contexts)) {
-                                        $data = array_replace_recursive(
-                                            $data, 
-                                            $filter['data']
-                                        );
-                                        break;
-                                    }
-
+                                    // Operator ==
                                     if ($filterContext['operator'] == "!=" && !in_array($filterContext['context'], $contexts)) {
                                         $data = array_replace_recursive(
                                             $data, 

--- a/library/Customizer/Applicators/ComponentData.php
+++ b/library/Customizer/Applicators/ComponentData.php
@@ -7,7 +7,7 @@ use Error;
 
 class ComponentData extends AbstractApplicator
 {
-    private $componentDataOptionKey = 'theme_mod_municipio_component_data';
+    public $optionKey = 'component';
 
     public function __construct()
     {
@@ -22,8 +22,9 @@ class ComponentData extends AbstractApplicator
      */
     public function storeComponentData($manager = null)
     {
-        $componentData = $this->calculateComponentData();
-        update_option($this->componentDataOptionKey, $componentData);
+        $this->setStatic(
+            $componentData = $this->calculateComponentData()
+        );
         return $componentData;
     }
 
@@ -35,9 +36,7 @@ class ComponentData extends AbstractApplicator
      */
     public function applyStoredComponentData($data)
     {
-        $storedComponentData = get_option($this->componentDataOptionKey, false);
-
-        // If storedComponentData is empty, calculate and store it
+        $storedComponentData = $this->getStatic();
         if ($storedComponentData === false) {
             $storedComponentData = $this->storeComponentData();
         }
@@ -48,13 +47,6 @@ class ComponentData extends AbstractApplicator
             $passFilterRules = false;
 
             foreach ($filter['contexts'] as $filterContext) {
-                // Correct faulty context configurations
-                if (is_string($filterContext)) {
-                    $filterContext = [
-                        'operator' => '==',
-                        'context' => $filterContext
-                    ];
-                }
 
                 // Operator and context must be set
                 if (!isset($filterContext['operator']) || !isset($filterContext['context'])) {

--- a/library/Customizer/Applicators/ControllerVariables.php
+++ b/library/Customizer/Applicators/ControllerVariables.php
@@ -2,7 +2,7 @@
 
 namespace Municipio\Customizer\Applicators;
 
-class ControllerVariables
+class ControllerVariables extends AbstractApplicator
 {
     private $controllerVarsOptionKey = 'theme_mod_municipio_controller_vars';
 
@@ -37,7 +37,7 @@ class ControllerVariables
     public function applicateStoredControllerVars()
     {
         if ($controllerVars = get_option($this->controllerVarsOptionKey, false)) {
-            return $controllerVars;
+            //return $controllerVars;
         }
         return $this->storeControllerVars(); // Fallback to calculate and store
     }
@@ -52,101 +52,39 @@ class ControllerVariables
     public function get($stack = [])
     {
         //Get field definition
-        $fields = \Kirki::$all_fields;
+        $fields = $this->getFields();
 
         //Determine what's a controller var, fetch it
         if (is_array($fields) && !empty($fields)) {
             foreach ($fields as $key => $field) {
-                if ($this->isControllerSetting($field)) {
-                    /**
-                     * Implementation of output active_callback functionality for output.
-                     * Can handle multiple AND statements.
-                     */
 
-                    if (!isset($field['active_callback'])) {
-                        $stack = $this->appendStack($stack, \Kirki::get_option($key), $key, $field);
-                    } elseif (is_string($field['active_callback']) && $field['active_callback'] === '__return_true') {
-                        $stack = $this->appendStack($stack, \Kirki::get_option($key), $key, $field);
-                    } elseif (is_string($field['active_callback']) && $field['active_callback'] === '__return_false') {
-                        $stack = $this->appendStack($stack, null, $key, $field);
-                    } elseif (is_array($field['active_callback']) && !empty($field['active_callback'])) {
-                        $shouldReturn = false;
-
-                        foreach ($field['active_callback'] as $cb) {
-                            $cb = (object) $cb;
-
-                            //Verify operator, before eval
-                            if ($this->isValidOperator($cb->operator) === false) {
-                                trigger_error("Provided operator in active callback for is not valid.", E_USER_ERROR);
-                            }
-
-                            //Verify value (sanity check)
-                            if (!preg_match('/^[a-z\d_-]+$/i', $cb->value)) {
-                                trigger_error("Provided value in active callback for is not valid, should be a string matching (a-z _ - digits).", E_USER_ERROR);
-                            }
-
-                            // Handle "contains" operator
-                            if ('contains' == $cb->operator) {
-                                $value = (array) \Kirki::get_option($cb->setting);
-                                if (in_array($cb->value, $value)) {
-                                    $shouldReturn = true;
-                                }
-                            } else {
-                                //Create compare string
-                                if (is_string($cb->value)) {
-                                    $cb->value = '"' . $cb->value . '"';
-                                }
-                                if (eval('return \Kirki::get_option("' . $cb->setting . '") ' . $cb->operator . ' ' . $cb->value . ';')) {
-                                    $shouldReturn = true;
-                                }
-                            }
-                        }
-
-                        if ($shouldReturn === true) {
-                            $stack = $this->appendStack($stack, \Kirki::get_option($key), $key, $field);
-                        } else {
-                            $stack = $this->appendStack($stack, null, $key, $field);
-                        }
-                    }
+                // Check if field is a controller
+                if (!$this->isFieldType($field, 'controller')) {
+                    continue;
                 }
+
+                if(!isset($field['active_callback']) || $this->isValidActiveCallback($field['active_callback'], $key)) {
+                    $stack = $this->appendStack(
+                        $stack, 
+                        \Kirki::get_option($key),
+                        $key,
+                        $field
+                    );
+                } else {
+                    $stack = $this->appendStack(
+                        $stack, 
+                        null,
+                        $key,
+                        $field
+                    );
+                }
+
             }
         }
         // Camel case response keys, and return
         return \Municipio\Helper\FormatObject::camelCase(
             (object) $stack
         );
-    }
-
-  /**
-   * Validate PHP operator
-   *
-   * @param string $operator
-   * @return bool
-   */
-    private function isValidOperator($operator): bool
-    {
-        if (in_array((string) $operator, ['contains', '==', '===', '!=', '<>', '!==', '>', '<', '>=', '<=', '<=>'])) {
-            return true;
-        }
-        return false;
-    }
-
-  /**
-   * Determines if should be handled as a controller var.
-   *
-   * @param array $field
-   * @return boolean
-   */
-    private function isControllerSetting($field, $lookForType = 'controller')
-    {
-        if (isset($field['output']) && is_array($field['output']) && !empty($field['output'])) {
-            foreach ($field['output'] as $output) {
-                if (isset($output['type']) && $output['type'] === $lookForType) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
    /**

--- a/library/Customizer/Applicators/ControllerVariables.php
+++ b/library/Customizer/Applicators/ControllerVariables.php
@@ -4,7 +4,7 @@ namespace Municipio\Customizer\Applicators;
 
 class ControllerVariables extends AbstractApplicator
 {
-    private $controllerVarsOptionKey = 'theme_mod_municipio_controller_vars';
+    public $optionKey = 'controller';
 
     public function __construct()
     {
@@ -18,13 +18,9 @@ class ControllerVariables extends AbstractApplicator
      * @return array
      */
     public function storeControllerVars($manager = null) {
-        $controllerVars = $this->get();
-
-        update_option(
-            $this->controllerVarsOptionKey, 
-            $controllerVars
+        $this->setStatic(
+            $controllerVars = $this->get()
         );
-
         return $controllerVars;
     }
 
@@ -36,8 +32,8 @@ class ControllerVariables extends AbstractApplicator
      */
     public function applicateStoredControllerVars()
     {
-        if ($controllerVars = get_option($this->controllerVarsOptionKey, false)) {
-            //return $controllerVars;
+        if ($controllerVars = $this->getStatic()) {
+            return $controllerVars;
         }
         return $this->storeControllerVars(); // Fallback to calculate and store
     }

--- a/library/Customizer/Applicators/Css.php
+++ b/library/Customizer/Applicators/Css.php
@@ -4,10 +4,10 @@ namespace Municipio\Customizer\Applicators;
 
 use Kirki\Module\CSS as KirkiCSS;
 
-class Css
+class Css extends AbstractApplicator
 {
   private $baseFontSize = '16px';
-  private $staticCssOptionKey = 'theme_mod_municipio_static_css';
+  public  $optionKey = 'css';
 
   public function __construct() {
     add_filter('kirki_' . \Municipio\Customizer::KIRKI_CONFIG . '_styles', array($this, 'filterFontSize'));
@@ -26,12 +26,10 @@ class Css
    * @return array
    */
   public function storeStaticStyles($manager = null) {
-    $styles = $this->getDynamic();
-    update_option(
-        $this->staticCssOptionKey, 
-        $styles
+    $this->setStatic(
+      $dynamicStyles = $this->getDynamic()
     );
-    return $styles;
+    return $dynamicStyles;
   }
 
   /**
@@ -50,9 +48,9 @@ class Css
    * 
    * @return string
    */
-  private function getStatic(): string
+  private function getStaticCss(): string
   {
-    $styles = get_option($this->staticCssOptionKey, false);
+    $styles = $this->getStatic();
     if($styles) {
       return $this->filterStyles(
         $styles
@@ -72,7 +70,7 @@ class Css
    */
   private function getHybrid(): string
   {
-    $static = $this->getStatic();
+    $static = $this->getStaticCss();
     if (!empty($static)) {
       return $static;
     }

--- a/library/Customizer/Applicators/Modifiers.php
+++ b/library/Customizer/Applicators/Modifiers.php
@@ -7,7 +7,7 @@ class Modifiers extends AbstractApplicator
 {
     public function __construct()
     {
-        add_action('wp', array($this, 'applyModifiers'));
+        //add_action('wp', array($this, 'applyModifiers'));
     }
 
     /**

--- a/library/Customizer/Applicators/Modifiers.php
+++ b/library/Customizer/Applicators/Modifiers.php
@@ -4,7 +4,7 @@ namespace Municipio\Customizer\Applicators;
 
 class Modifiers extends AbstractApplicator
 {
-    private $modifiersOptionKey = 'theme_mod_municipio_modifiers';
+    public $optionKey = 'modifiers';
 
     public function __construct()
     {
@@ -19,8 +19,10 @@ class Modifiers extends AbstractApplicator
      */
     public function storeModifiers($manager = null)
     {
-        $modifiers = $this->calculateModifiers();
-        update_option($this->modifiersOptionKey, $modifiers);
+        $this->setStatic(
+            $storedModifiers = $this->calculateModifiers()
+        );
+        return $storedModifiers;
     }
 
     /**
@@ -32,7 +34,7 @@ class Modifiers extends AbstractApplicator
      */
     public function applyStoredModifiers($modifiers, $contexts)
     {
-        $storedModifiers = get_option($this->modifiersOptionKey, false);
+        $storedModifiers = $this->getStatic();
 
         // If storedModifiers is empty, calculate and store them
         if ($storedModifiers === false) {

--- a/library/Customizer/Applicators/Modifiers.php
+++ b/library/Customizer/Applicators/Modifiers.php
@@ -4,22 +4,87 @@ namespace Municipio\Customizer\Applicators;
 
 class Modifiers extends AbstractApplicator
 {
+    private $modifiersOptionKey = 'theme_mod_municipio_modifiers';
+
     public function __construct()
     {
-        add_action('wp', array($this, 'applyModifiers'));
+        add_action('customize_save_after', array($this, 'storeModifiers'), 50);
+        add_filter('ComponentLibrary/Component/Modifier', array($this, 'applyStoredModifiers'), 10, 2);
     }
 
     /**
-     * Apply modifiers
-     *
+     * Calculate and store modifiers on save of customizer
+     * 
      * @return void
      */
-    public function applyModifiers()
+    public function storeModifiers($manager = null)
     {
-        // Get field definition
-        $fields = $this->getFields();
+        $modifiers = $this->calculateModifiers();
+        update_option($this->modifiersOptionKey, $modifiers);
+    }
 
-        // Determine what's a controller var, fetch it
+    /**
+     * Apply stored modifiers
+     *
+     * @param array $modifiers
+     * @param array $contexts
+     * @return array
+     */
+    public function applyStoredModifiers($modifiers, $contexts)
+    {
+        $storedModifiers = get_option($this->modifiersOptionKey, false);
+
+        // If storedModifiers is empty, calculate and store them
+        if ($storedModifiers === false) {
+            $storedModifiers = $this->storeModifiers();
+        }
+
+        if (!is_array($contexts)) {
+            $contexts = [$contexts];
+        }
+
+        if (!is_array($modifiers)) {
+            $modifiers = [$modifiers];
+        }
+
+        foreach ($storedModifiers as $filter) {
+            $passFilterRules = false;
+
+            foreach ($filter['contexts'] as $filterContext) {
+                // Operator and context must be set
+                if (!isset($filterContext['operator']) || !isset($filterContext['context'])) {
+                    throw new \Error("Operator must be != or == to be used in ComponentData applicator. Context must be set. Provided values: " . print_r($filterContext, true));
+                }
+
+                // Operator must be != or ==
+                if (!in_array($filterContext['operator'], ["!=", "=="])) {
+                    throw new \Error("Operator must be != or == to be used in ComponentData applicator. Provided value: " . $filterContext['operator']);
+                }
+
+                if (($filterContext['operator'] == "==" && in_array($filterContext['context'], $contexts)) ||
+                    ($filterContext['operator'] == "!=" && !in_array($filterContext['context'], $contexts))) {
+                    $passFilterRules = true;
+                }
+            }
+
+            if ($passFilterRules) {
+                $modifiers[] = $filter['value'];
+            }
+        }
+
+        return $modifiers;
+    }
+
+    /**
+     * Calculate modifiers based on fields
+     *
+     * @return array
+     */
+    private function calculateModifiers()
+    {
+        $fields = $this->getFields();
+        $modifiers = [];
+
         if (is_array($fields) && !empty($fields)) {
             foreach ($fields as $key => $field) {
                 if (!$this->isFieldType($field, 'modifier')) {
@@ -27,18 +92,15 @@ class Modifiers extends AbstractApplicator
                 }
 
                 if (!isset($field['active_callback']) || $this->isValidActiveCallback($field['active_callback'], $key)) {
-                    // Check if the field has an 'output' key
                     if (!isset($field['output']) || !is_array($field['output'])) {
                         continue;
                     }
 
                     foreach ($field['output'] as $output) {
-                        // Check if the output has a 'context' key
                         if (!isset($output['context']) || !is_array($output['context'])) {
                             continue;
                         }
 
-                        // Ensure context is correctly formatted. TODO: Correct faulty config.
                         foreach ($output['context'] as $contextKey => $context) {
                             if (!is_array($context)) {
                                 $output['context'][$contextKey] = [
@@ -48,49 +110,15 @@ class Modifiers extends AbstractApplicator
                             }
                         }
 
-                        // Prepare the filter for the add_filter call
-                        $filter = [
+                        $modifiers[] = [
                             'contexts' => $output['context'],
-                            'value' => $key,
+                            'value' => \Kirki::get_option($key),
                         ];
-
-                        add_filter('ComponentLibrary/Component/Modifier', function ($modifiers, $contexts) use ($filter) {
-                            if (!is_array($contexts)) {
-                                $contexts = [$contexts];
-                            }
-
-                            if (!is_array($modifiers)) {
-                                $modifiers = [$modifiers];
-                            }
-
-                            $passFilterRules = false;
-
-                            foreach ($filter['contexts'] as $filterContext) {
-                                // Operator and context must be set
-                                if (!isset($filterContext['operator']) || !isset($filterContext['context'])) {
-                                    throw new \Error("Operator must be != or == to be used in ComponentData applicator. Context must be set. Provided values: " . print_r($filterContext, true));
-                                }
-
-                                // Operator must be != or ==
-                                if (!in_array($filterContext['operator'], ["!=", "=="])) {
-                                    throw new \Error("Operator must be != or == to be used in ComponentData applicator. Provided value: " . $filterContext['operator']);
-                                }
-
-                                if (($filterContext['operator'] == "==" && in_array($filterContext['context'], $contexts)) ||
-                                    ($filterContext['operator'] == "!=" && !in_array($filterContext['context'], $contexts))) {
-                                    $passFilterRules = true;
-                                }
-                            }
-
-                            if ($passFilterRules) {
-                                $modifiers[] =  \Kirki::get_option($filter['value']);
-                            }
-
-                            return $modifiers;
-                        }, 10, 2);
                     }
                 }
             }
         }
+
+        return $modifiers;
     }
 }

--- a/library/Customizer/Sections/Module/Posts.php
+++ b/library/Customizer/Sections/Module/Posts.php
@@ -96,15 +96,15 @@ class Posts
                 'type'    => 'component_data',
                 'dataKey' => 'displayIcon',
                 'context' => [
-                  'module.posts.index',
-                  'module.posts.segment',
-                  'module.posts.block',
-                  'module.posts.collection__item',
-                  'module.manual-input.card',
-                  'module.manual-input.collection__item',
-                  'module.manual-input.block',
-                  'module.manual-input.segment'
-                ]
+                  ['context' => 'module.posts.segment', 'operator' => '=='],
+                  ['context' => 'module.posts.block', 'operator' => '=='],
+                  ['context' => 'module.posts.collection__item', 'operator' => '=='],
+                  ['context' => 'module.manual-input.card', 'operator' => '=='],
+                  ['context' => 'module.manual-input.collection__item', 'operator' => '=='],
+                  ['context' => 'module.manual-input.block', 'operator' => '=='],
+                  ['context' => 'module.manual-input.segment', 'operator' => '=='],
+                  ['context' => 'module.posts.index', 'operator' => '==']
+                ],
               ],
           ],
         ]);

--- a/library/Customizer/Sections/Search.php
+++ b/library/Customizer/Sections/Search.php
@@ -51,13 +51,13 @@ class Search
          'priority'        => 10,
          'choices'         => $this->getHeroSearchButtonOptions(),
          'output'          => [
-             [
-                 'type'    => 'component_data',
-                 'dataKey' => 'color',
-                 'context' => [
-                     'hero.search.button',
-                 ]
-             ],
+            [
+                'type'    => 'component_data',
+                'dataKey' => 'color',
+                'context' => [
+                    ['context' => 'hero.search.button', 'operator' => "=="]
+                ]
+            ],
          ],
          'active_callback' => [
              [

--- a/library/Customizer/Sections/SliderHero.php
+++ b/library/Customizer/Sections/SliderHero.php
@@ -49,7 +49,7 @@ class SliderHero
             'output'   => [
                 [
                     'type'    => 'modifier',
-                    'context' => ['sidebar.slider-area.module.slider-item']
+                    'context' => ['context' => 'sidebar.slider-area.module.slider-item', 'operator' => '==']
                 ]
             ],
         ]);
@@ -71,7 +71,7 @@ class SliderHero
             'output'   => [
                 [
                     'type'    => 'modifier',
-                    'context' => ['sidebar.slider-area.module.slider-item']
+                    'context' => ['context' => 'sidebar.slider-area.module.slider-item', 'operator' => '==']
                 ]
             ],
         ]);
@@ -93,7 +93,7 @@ class SliderHero
                 [
                     'type'    => 'component_data',
                     'dataKey' => 'overlay',
-                    'context' => ['sidebar.slider-area.module.slider-item']
+                    'context' => ['context' => 'sidebar.slider-area.module.slider-item', 'operator' => '==']
                 ]
             ],
         ]);


### PR DESCRIPTION
The refactor aims to remove all use of eval functions to calculate output. This will also decrease frontend load by shifting all Kirki::getField actions to the customizer save hook. All data will be stored in a static option, that is used to render the pages. 