### PR TITLE
fix: clear cache of oembeds.

### DIFF
--- a/library/Upgrade.php
+++ b/library/Upgrade.php
@@ -13,7 +13,7 @@ use WpService\Contracts\GetThemeMod;
  */
 class Upgrade
 {
-    private $dbVersion    = 30; //The db version we want to achive
+    private $dbVersion    = 31; //The db version we want to achive
     private $dbVersionKey = 'municipio_db_version';
     private $db;
 
@@ -621,6 +621,11 @@ class Upgrade
             }
         }
         
+        return true;
+    }
+
+    private function v_31($db): bool {
+        $db->query("DELETE FROM {$db->postmeta} WHERE meta_key LIKE '_oembed%'");
         return true;
     }
 


### PR DESCRIPTION
This PR introduces a change to remove all post metadata entries in the WordPress database where the meta_key matches _oembed%. The purpose of this change is to clean up unnecessary or outdated oEmbed cache data from the wp_postmeta table, this is due to a change in the icons rendering causing icons not to appear. 