### PR TITLE
fix: archive helper camel case

### DIFF
--- a/library/Helper/Archive.php
+++ b/library/Helper/Archive.php
@@ -34,7 +34,7 @@ class Archive
      */
     public static function camelCasePostTypeName($postType)
     {
-        return str_replace(' ', '', ucwords(str_replace('-', ' ', $postType)));
+        return str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $postType)));
     }
 
     /**


### PR DESCRIPTION
Fixed the issue where the archive helper camel cases post_type to Post_type, different to the customizer that camel cases it to PostType. Without this fix we get a mismatch when the archive tries to fetch the customizer data.