### PR TITLE
Don't try to get page template if no object was queried

### DIFF
--- a/library/Template.php
+++ b/library/Template.php
@@ -349,7 +349,7 @@ class Template
                     }
 
                     // Template slug
-                    if (get_page_template_slug()) {
+                    if (get_queried_object() && get_page_template_slug()) {
                         $type = get_page_template_slug();
                     }
 


### PR DESCRIPTION
For instance on search or an archive