### PR TITLE
fix: normalize now

### DIFF
--- a/library/Customizer/Applicators/ApplicatorCache.php
+++ b/library/Customizer/Applicators/ApplicatorCache.php
@@ -228,7 +228,7 @@ class ApplicatorCache implements Hookable, ApplicatorCacheInterface
             )
         );
 
-        return $latestDate ? strtotime($latestDate) : time();
+        return $latestDate ? strtotime($latestDate) : round(time() / 10) * 10;
     }
 
   /**


### PR DESCRIPTION
This enshures that a fallback cache key, dosen't regenerate if saving takes a long time. 