### PR TITLE
feat(api/pdf): enhance PdfArchiveEndpoint with date filtering arguments

### DIFF
--- a/library/Api/Pdf/PdfArchiveEndpoint.php
+++ b/library/Api/Pdf/PdfArchiveEndpoint.php
@@ -135,6 +135,14 @@ class PdfArchiveEndpoint extends RestApiEndpoint
         return $postsWithTerms;
     }
 
+    /**
+     * Retrieves posts from the archive query based on the given parameters.
+     *
+     * @param string $postType    The post type.
+     * @param array  $queryParams The query parameters.
+     *
+     * @return array The retrieved posts.
+     */
     private function getPostsFromArchiveQuery($postType = '', $queryParams = false)
     {
         $orderBy   = get_theme_mod('archive_' . $postType . '_order_by', 'post_date');

--- a/library/Api/Pdf/PdfArchiveEndpoint.php
+++ b/library/Api/Pdf/PdfArchiveEndpoint.php
@@ -30,7 +30,17 @@ class PdfArchiveEndpoint extends RestApiEndpoint
         return register_rest_route(self::NAMESPACE, self::ROUTE, array(
             'methods'             => 'GET',
             'callback'            => array($this, 'handleRequest'),
-            'permission_callback' => '__return_true'
+            'permission_callback' => '__return_true',
+            'args'                => [
+                'after'  => [
+                    'required'          => false,
+                    'validate_callback' => fn ($param) => is_string($param) && strtotime($param),
+                ],
+                'before' => [
+                    'required'          => false,
+                    'validate_callback' => fn ($param) => is_string($param) && strtotime($param),
+                ]
+            ],
         ));
     }
 
@@ -88,7 +98,7 @@ class PdfArchiveEndpoint extends RestApiEndpoint
      */
     private function handleArchivePosts($postType = '', $queryParams = false)
     {
-        $posts = $this->getPostsFromArchiveQuery($postType);
+        $posts = $this->getPostsFromArchiveQuery($postType, $queryParams);
 
         $postsWithTerms    = [];
         $postsWithoutTerms = [];
@@ -125,7 +135,7 @@ class PdfArchiveEndpoint extends RestApiEndpoint
         return $postsWithTerms;
     }
 
-    private function getPostsFromArchiveQuery($postType = '')
+    private function getPostsFromArchiveQuery($postType = '', $queryParams = false)
     {
         $orderBy   = get_theme_mod('archive_' . $postType . '_order_by', 'post_date');
         $order     = get_theme_mod('archive_' . $postType . '_order_direction');
@@ -135,7 +145,7 @@ class PdfArchiveEndpoint extends RestApiEndpoint
             'post_type'      => $postType,
             'tax_query'      => [],
             'date_query'     => [
-                'inclusive' => true,
+                'inclusive' => false,
             ],
             'posts_per_page' => -1,
             'orderby'        => !empty($orderBy) ? $orderBy : 'post_date',
@@ -143,15 +153,14 @@ class PdfArchiveEndpoint extends RestApiEndpoint
         ];
 
         if (!empty($queryParams) && is_array($queryParams)) {
-            if (!empty($queryParams['from'])) {
-                $args['date_query']['after'] = $queryParams['from'];
-                unset($queryParams['from']);
+            if (!empty($queryParams['after'])) {
+                $args['date_query']['after'] = $queryParams['after'];
+                unset($queryParams['after']);
             }
 
-            if (!empty($queryParams['to'])) {
-                $args['date_query']['before']  = $queryParams['to'];
-                $args['date_query']['compare'] = '<=';
-                unset($queryParams['to']);
+            if (!empty($queryParams['before'])) {
+                $args['date_query']['before'] = $queryParams['before'];
+                unset($queryParams['before']);
             }
 
             if (isset($args['date_query']['after']) && isset($args['date_query']['before'])) {


### PR DESCRIPTION
This pull request includes several changes to the `PdfArchiveEndpoint` class in the `library/Api/Pdf` directory. The main updates involve adding query parameter validation, modifying method signatures, and updating the date query logic.

### Enhancements to query parameter handling:

* [`library/Api/Pdf/PdfArchiveEndpoint.php`](diffhunk://#diff-fba111877bb66fb5fe3442234d7d1b2d60e64c33c04f892bb22780f60a704fe4L33-R43): Added validation for `after` and `before` query parameters in the `handleRegisterRestRoute` method.
* [`library/Api/Pdf/PdfArchiveEndpoint.php`](diffhunk://#diff-fba111877bb66fb5fe3442234d7d1b2d60e64c33c04f892bb22780f60a704fe4L91-R101): Updated the `handleRequest` method to pass query parameters to the `getPostsFromArchiveQuery` method.

### Method signature updates:

* [`library/Api/Pdf/PdfArchiveEndpoint.php`](diffhunk://#diff-fba111877bb66fb5fe3442234d7d1b2d60e64c33c04f892bb22780f60a704fe4L128-R146): Modified the `getPostsFromArchiveQuery` method to accept an additional `$queryParams` parameter and added a docblock for better documentation.

### Date query logic improvements:

* [`library/Api/Pdf/PdfArchiveEndpoint.php`](diffhunk://#diff-fba111877bb66fb5fe3442234d7d1b2d60e64c33c04f892bb22780f60a704fe4L138-R171): Changed the `inclusive` flag in the date query to `false` and updated the handling of `after` and `before` query parameters.