### PR TITLE
feat: autologin

### DIFF
--- a/library/AcfFields/json/options-login-redirect.json
+++ b/library/AcfFields/json/options-login-redirect.json
@@ -1,0 +1,52 @@
+[{
+    "key": "group_675aecfbf2f3d",
+    "title": "Broken Links",
+    "fields": [
+        {
+            "key": "field_675aecfc0707a",
+            "label": "Autologin",
+            "name": "municipio_redirect_to_login_when_internal_context",
+            "aria-label": "",
+            "type": "true_false",
+            "instructions": "This feature will redirect the user to the login page, if an internal context has been detected.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "* Requires Broken Links Detector Plugin",
+            "default_value": 0,
+            "ui_on_text": "Enabled",
+            "ui_off_text": "Disabled",
+            "ui": 1
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "options_page",
+                "operator": "==",
+                "value": "login-logout"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "left",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_rest": 0,
+    "acfe_display_title": "",
+    "acfe_autosync": [
+        "json"
+    ],
+    "acfe_form": 0,
+    "acfe_meta": "",
+    "acfe_note": ""
+}]
+

--- a/library/AcfFields/php/options-login-redirect.php
+++ b/library/AcfFields/php/options-login-redirect.php
@@ -1,0 +1,55 @@
+<?php 
+
+if (function_exists('acf_add_local_field_group')) {
+    acf_add_local_field_group(array(
+    'key' => 'group_675aecfbf2f3d',
+    'title' => __('Broken Links', 'municipio'),
+    'fields' => array(
+        0 => array(
+            'key' => 'field_675aecfc0707a',
+            'label' => __('Autologin', 'municipio'),
+            'name' => 'municipio_redirect_to_login_when_internal_context',
+            'aria-label' => '',
+            'type' => 'true_false',
+            'instructions' => __('This feature will redirect the user to the login page, if an internal context has been detected.', 'municipio'),
+            'required' => 0,
+            'conditional_logic' => 0,
+            'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
+            ),
+            'message' => __('* Requires Broken Links Detector Plugin', 'municipio'),
+            'default_value' => 0,
+            'ui_on_text' => __('Enabled', 'municipio'),
+            'ui_off_text' => __('Disabled', 'municipio'),
+            'ui' => 1,
+        ),
+    ),
+    'location' => array(
+        0 => array(
+            0 => array(
+                'param' => 'options_page',
+                'operator' => '==',
+                'value' => 'login-logout',
+            ),
+        ),
+    ),
+    'menu_order' => 0,
+    'position' => 'normal',
+    'style' => 'default',
+    'label_placement' => 'left',
+    'instruction_placement' => 'label',
+    'hide_on_screen' => '',
+    'active' => true,
+    'description' => '',
+    'show_in_rest' => 0,
+    'acfe_display_title' => '',
+    'acfe_autosync' => array(
+        0 => 'json',
+    ),
+    'acfe_form' => 0,
+    'acfe_meta' => '',
+    'acfe_note' => '',
+));
+}

--- a/library/App.php
+++ b/library/App.php
@@ -320,6 +320,31 @@ class App
          * MiniOrange integration
          */
         $this->setUpMiniOrangeIntegration();
+
+        /**
+         * Broken links
+         */
+        $this->setUpBrokenLinksIntegration();
+    }
+
+    /**
+     * Sets up the broken links integration.
+     *
+     * This method initializes the broken links integration by creating an instance of the
+     * RedirectToLoginWhenInternalContext class and passing the WordPress service instance.
+     *
+     * @return void
+     */
+
+    private function setUpBrokenLinksIntegration(): void
+    {
+        $config = new \Municipio\Integrations\BrokenLinks\Config\BrokenLinksConfig();
+        if($config->isEnabled() === false) {
+            return;
+        }
+
+        $redirect = new \Municipio\Integrations\BrokenLinks\RedirectToLoginWhenInternalContext($this->wpService, $config);
+        $redirect->addHooks();
     }
 
     /**

--- a/library/App.php
+++ b/library/App.php
@@ -339,7 +339,7 @@ class App
     private function setUpBrokenLinksIntegration(): void
     {
         $config = new \Municipio\Integrations\BrokenLinks\Config\BrokenLinksConfig();
-        if($config->isEnabled() === false) {
+        if ($config->isEnabled() === false) {
             return;
         }
 
@@ -385,7 +385,7 @@ class App
     private function setUpMiniOrangeIntegration(): void
     {
         $config = new \Municipio\Admin\Integrations\MiniOrange\Config\MiniOrangeConfig();
-        if($config->isEnabled() === false) {
+        if ($config->isEnabled() === false) {
             return;
         }
 

--- a/library/Bootstrap.php
+++ b/library/Bootstrap.php
@@ -110,6 +110,7 @@ add_action('init', function () use ($wpService) {
         'options-customize-header'                   => 'group_5afa93c0a25e1',
         'options-customize-footer'                   => 'group_5afa94c88e1aa',
         'options-login-logout'                       => 'group_67597150948c7',
+        'options-login-redirect'                     => 'group_675aecfbf2f3d',
         'resource-fields'                            => 'group_653a509450198',
         'user-author-image'                          => 'group_56c714b46105e',
         'widget-contact'                             => 'group_56c58bade87dc',

--- a/library/Controller/BaseController.php
+++ b/library/Controller/BaseController.php
@@ -368,7 +368,7 @@ class BaseController
         $this->data['hasMainMenu']           = $this->hasMainMenu();
 
         $this->data['structuredData'] = \Municipio\Helper\Data::normalizeStructuredData([]);
-        
+
         //Notice storage
         $this->data['notice'] = [];
 

--- a/library/Controller/BaseController.php
+++ b/library/Controller/BaseController.php
@@ -443,32 +443,13 @@ class BaseController
      */
     private function getCurrentUrl(array $queryParam = []): string
     {
-        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http';
-        $host = filter_var($_SERVER['SERVER_NAME'] ?? '', FILTER_SANITIZE_URL);
-        $requestUri = filter_var($_SERVER['REQUEST_URI'] ?? '', FILTER_SANITIZE_URL);
+        $permalink = $this->wpService->getPermalink(\Municipio\Helper\CurrentPostId::get());
 
-        if (empty($host)) {
+        if (!$permalink) {
             return '';
         }
 
-        // Parse the current query string
-        $urlParts = parse_url($requestUri);
-        $currentQueryParams = [];
-        if (isset($urlParts['query'])) {
-            parse_str($urlParts['query'], $currentQueryParams);
-        }
-
-        // Merge the current query parameters with the new ones
-        $mergedQueryParams = array_merge($currentQueryParams, $queryParam);
-
-        // Build the new query string
-        $newQueryString = http_build_query($mergedQueryParams);
-
-        // Build the new request URI
-        $path = $urlParts['path'] ?? '';
-        $newRequestUri = $path . (!empty($newQueryString) ? '?' . $newQueryString : '');
-
-        return sprintf('%s://%s%s', $scheme, $host, $newRequestUri);
+        return add_query_arg($queryParam, $permalink);
     }
 
     /**

--- a/library/Integrations/BrokenLinks/Config/BrokenLinksConfig.php
+++ b/library/Integrations/BrokenLinks/Config/BrokenLinksConfig.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Municipio\Integrations\BrokenLinks\Config;
+
+class BrokenLinksConfig
+{
+  public function isEnabled(): bool {
+    return class_exists('BrokenLinkDetector\App');
+  }
+  public function shouldRedirectToLoginPageWhenInternalContext(): bool
+  {
+    return (bool) get_option('options_municipio_redirect_to_login_when_internal_context', false) ?? false;
+  }
+}

--- a/library/Integrations/BrokenLinks/Config/BrokenLinksConfig.php
+++ b/library/Integrations/BrokenLinks/Config/BrokenLinksConfig.php
@@ -4,11 +4,12 @@ namespace Municipio\Integrations\BrokenLinks\Config;
 
 class BrokenLinksConfig
 {
-  public function isEnabled(): bool {
-    return class_exists('BrokenLinkDetector\App');
-  }
-  public function shouldRedirectToLoginPageWhenInternalContext(): bool
-  {
-    return (bool) get_option('options_municipio_redirect_to_login_when_internal_context', false) ?? false;
-  }
+    public function isEnabled(): bool
+    {
+        return class_exists('BrokenLinkDetector\App');
+    }
+    public function shouldRedirectToLoginPageWhenInternalContext(): bool
+    {
+        return (bool) get_option('options_municipio_redirect_to_login_when_internal_context', false) ?? false;
+    }
 }

--- a/library/Integrations/BrokenLinks/Config/BrokenLinksConfigInterface.php
+++ b/library/Integrations/BrokenLinks/Config/BrokenLinksConfigInterface.php
@@ -4,6 +4,6 @@ namespace Municipio\Integrations\BrokenLinks\Config;
 
 interface BrokenLinksConfigInterface
 {
-  public function isEnabled(): bool;
-  public function shouldRedirectToLoginPageWhenInternalContext(): bool;
+    public function isEnabled(): bool;
+    public function shouldRedirectToLoginPageWhenInternalContext(): bool;
 }

--- a/library/Integrations/BrokenLinks/Config/BrokenLinksConfigInterface.php
+++ b/library/Integrations/BrokenLinks/Config/BrokenLinksConfigInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Municipio\Integrations\BrokenLinks\Config;
+
+interface BrokenLinksConfigInterface
+{
+  public function isEnabled(): bool;
+  public function shouldRedirectToLoginPageWhenInternalContext(): bool;
+}

--- a/library/Integrations/BrokenLinks/RedirectToLoginWhenInternalContext.php
+++ b/library/Integrations/BrokenLinks/RedirectToLoginWhenInternalContext.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Municipio\Integrations\BrokenLinks;
+
+use Municipio\HooksRegistrar\Hookable;
+use Municipio\Integrations\BrokenLinks\Config\BrokenLinksConfig;
+use WpOrg\Requests\Exception\Http;
+use WpService\WpService;
+
+class RedirectToLoginWhenInternalContext implements Hookable
+{
+  public function __construct(private WpService $wpService, private BrokenLinksConfig $config){}
+
+  public function addHooks() : void
+  {
+    $this->wpService->addAction('wp_head', [$this, 'redirectIfBrokenLink']);
+  }
+
+  /**
+   * Redirects to login page if broken link is detected
+   * 
+   * @return void
+   */
+  public function redirectIfBrokenLink()
+  {
+    if($this->config->shouldRedirectToLoginPageWhenInternalContext()) {
+      if(!$this->wpService->isUserLoggedIn()) {
+
+        $currentUrl = $this->wpService->getPermalink(\Municipio\Helper\CurrentPostId::get());
+
+        echo $this->render(
+          $this->wpService->wpLoginUrl($currentUrl)
+        );
+      }
+    }
+  }
+
+  /**
+   * Adds JS to redirect to login page
+   * 
+   * @return void
+   */
+  public function render($loginUrl) {
+    return sprintf(
+        '<script>
+            document.addEventListener("brokenLinkContextDetectionInternal", () => {
+                window.location.href = "%s";
+            });
+        </script>',
+        $loginUrl
+    );
+  }
+}

--- a/library/Integrations/BrokenLinks/RedirectToLoginWhenInternalContext.php
+++ b/library/Integrations/BrokenLinks/RedirectToLoginWhenInternalContext.php
@@ -34,13 +34,13 @@ class RedirectToLoginWhenInternalContext implements Hookable
 
                 echo sprintf(
                     '<script>
-              document.addEventListener("brokenLinkContextDetectionInternal", () => {
-                const loginLockKey = "%s";
-                if (!sessionStorage.getItem(loginLockKey)) {
-                  window.location.href = "%s";
-                }
-              });
-          </script>',
+                        document.addEventListener("brokenLinkContextDetectionInternal", () => {
+                          const loginLockKey = "%s";
+                          if (!sessionStorage.getItem(loginLockKey)) {
+                            window.location.href = "%s";
+                          }
+                        });
+                    </script>',
                     self::LOGIN_LOCK_KEY,
                     esc_js($currentUrl)
                 );
@@ -58,10 +58,10 @@ class RedirectToLoginWhenInternalContext implements Hookable
         if ((bool)($_GET['loggedout'] ?? false) && !$this->wpService->isUserLoggedIn()) {
             echo sprintf(
                 '<script>
-              document.addEventListener("DOMContentLoaded", function() {
-                  sessionStorage.setItem("%s", "true");
-              });
-          </script>',
+                    document.addEventListener("DOMContentLoaded", function() {
+                        sessionStorage.setItem("%s", "true");
+                    });
+                </script>',
                 self::LOGIN_LOCK_KEY
             );
         }

--- a/library/Integrations/BrokenLinks/RedirectToLoginWhenInternalContext.php
+++ b/library/Integrations/BrokenLinks/RedirectToLoginWhenInternalContext.php
@@ -9,30 +9,31 @@ use WpService\WpService;
 
 class RedirectToLoginWhenInternalContext implements Hookable
 {
-  private const LOGIN_LOCK_KEY = 'municipioLoginLock';
+    private const LOGIN_LOCK_KEY = 'municipioLoginLock';
 
-  public function __construct(private WpService $wpService, private BrokenLinksConfig $config){}
+    public function __construct(private WpService $wpService, private BrokenLinksConfig $config)
+    {
+    }
 
-  public function addHooks() : void
-  {
-    $this->wpService->addAction('wp_head', [$this, 'redirectIfBrokenLink']);
-    $this->wpService->addAction('wp_head', [$this, 'createLoginLockLoggedOut']);
-  }
+    public function addHooks(): void
+    {
+        $this->wpService->addAction('wp_head', [$this, 'redirectIfBrokenLink']);
+        $this->wpService->addAction('wp_head', [$this, 'createLoginLockLoggedOut']);
+    }
 
   /**
    * Redirects to login page if internal context is detected
-   * 
+   *
    * @return void
    */
-  public function redirectIfBrokenLink()
-  {
-    if($this->config->shouldRedirectToLoginPageWhenInternalContext()) {
-      if(!(bool)($_GET['loggedout'] ?? false) && !$this->wpService->isUserLoggedIn()) {
+    public function redirectIfBrokenLink()
+    {
+        if ($this->config->shouldRedirectToLoginPageWhenInternalContext()) {
+            if (!(bool)($_GET['loggedout'] ?? false) && !$this->wpService->isUserLoggedIn()) {
+                $currentUrl = $this->wpService->getPermalink(\Municipio\Helper\CurrentPostId::get());
 
-        $currentUrl = $this->wpService->getPermalink(\Municipio\Helper\CurrentPostId::get());
-
-        echo sprintf(
-          '<script>
+                echo sprintf(
+                    '<script>
               document.addEventListener("brokenLinkContextDetectionInternal", () => {
                 const loginLockKey = "%s";
                 if (!sessionStorage.getItem(loginLockKey)) {
@@ -40,29 +41,29 @@ class RedirectToLoginWhenInternalContext implements Hookable
                 }
               });
           </script>',
-          self::LOGIN_LOCK_KEY,
-          esc_js($currentUrl)
-        );
-      }
+                    self::LOGIN_LOCK_KEY,
+                    esc_js($currentUrl)
+                );
+            }
+        }
     }
-  }
 
   /**
    * Create login lock when logging out
-   * 
+   *
    * @return void
    */
-  public function createLoginLockLoggedOut()
-  {
-    if ((bool)($_GET['loggedout'] ?? false) && !$this->wpService->isUserLoggedIn()) {
-      echo sprintf(
-          '<script>
+    public function createLoginLockLoggedOut()
+    {
+        if ((bool)($_GET['loggedout'] ?? false) && !$this->wpService->isUserLoggedIn()) {
+            echo sprintf(
+                '<script>
               document.addEventListener("DOMContentLoaded", function() {
                   sessionStorage.setItem("%s", "true");
               });
           </script>',
-          self::LOGIN_LOCK_KEY
-      );
+                self::LOGIN_LOCK_KEY
+            );
+        }
     }
-  }
 }


### PR DESCRIPTION
This pull request introduces a new feature to handle broken links by redirecting users to the login page when an internal context is detected. The changes include updates to JSON and PHP configuration files, modifications to existing classes, and the addition of new classes for handling the broken links integration.

### New Feature: Broken Links Integration

* **Configuration Changes:**
  * Added a new JSON configuration file `options-login-redirect.json` to define the "Autologin" field for the broken links feature.
  * Updated the PHP configuration file `options-login-redirect.php` to register the new "Autologin" field with Advanced Custom Fields (ACF).
  * Modified `library/Bootstrap.php` to include the new configuration group `options-login-redirect`.

* **Codebase Enhancements:**
  * Updated `library/App.php` to set up the broken links integration by adding the `setUpBrokenLinksIntegration` method.
  * Simplified URL construction in `BaseController.php` by using the `getPermalink` method from the `wpService`.

* **New Classes:**
  * Added `BrokenLinksConfig` and `BrokenLinksConfigInterface` classes to manage the configuration for the broken links feature. [[1]](diffhunk://#diff-a540ddd57e864c13f42d12695233d4d434659857bafe0985a197412b3809505aR1-R15) [[2]](diffhunk://#diff-d37021e235ad6f9125785d468aa9fe33736bf40f193f66db3be39d3ccbc475e7R1-R9)
  * Introduced `RedirectToLoginWhenInternalContext` class to handle the redirection logic and add necessary hooks.