### PR TITLE
feat: custom font loader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "symfony/polyfill-mbstring": "1.17.0",
         "helsingborg-stad/acf-export-manager": ">=1.0.0",
         "pragmarx/ia-arr": "^7.3",
-        "ouun/kirki-module-fonts_upload": "^1.0.1",
         "symfony/polyfill-php80": "^1.27",
         "dompdf/dompdf": "^2.0.4",
         "spatie/schema-org": "^3.9",

--- a/library/Customizer.php
+++ b/library/Customizer.php
@@ -158,10 +158,9 @@ class Customizer
             'disable_output'    => true
         ));
 
-        // Custom fonts support (parse uploaded fonts)
-        if (class_exists('\Kirki\Module\FontUploads')) {
-            new \Kirki\Module\FontUploads();
-        }
+        //Init font uploads
+        $fontUploads = new \Municipio\Customizer\FontUploads\FontUploads($this->wpService);
+        $fontUploads->addHooks();
 
         //Applicators [Applies settings on the frontend]
         $this->initApplicators();

--- a/library/Customizer/FontUploads/FontUploads.php
+++ b/library/Customizer/FontUploads/FontUploads.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Municipio\Customizer\FontUploads;
+
+use WpService\WpService;
+use Municipio\HooksRegistrar\Hookable;
+
+/**
+ * Font uploads
+ * 
+ * This class allows you to upload custom fonts to the WordPress media library and use them in the customizer.
+ * 
+ * @source https://github.com/ouun/kirki-module-fonts_upload
+ * License: MIT
+ */
+class FontUploads implements Hookable {
+
+	public $allowedMimes = array(
+		'woff'  => 'application/font-woff',
+		'woff2' => 'application/font-woff2',
+	);
+
+	public function __construct(private WpService $wpService) {}
+
+	public function addHooks(): void
+	{
+		$this->wpService->addFilter('upload_mimes', array($this, 'addFontMimes'), 1, 1);
+		$this->wpService->addFilter('kirki_fonts_standard_fonts', array($this, 'addUploadedFontsToStack'), 1, 100);
+		$this->wpService->addAction('kirki_dynamic_css', array($this, 'getUploadedFontsCss'), 0, 20);
+	}
+
+	/**
+	 * Get uploaded fonts
+	 *
+	 * @return array
+	 */
+	public function getUploadedFonts(): array
+	{
+		$fontAttachments = new \WP_Query( array(
+			'post_type'      => 'attachment',
+			'posts_per_page' => 50,
+			'post_status'    => ['publish', 'inherit'],
+			'post_mime_type' => $this->allowedMimes
+		));
+
+		$fonts = [];
+
+		foreach ($fontAttachments->posts as $font) {
+			if ($url = $this->wpService->wpGetAttachmentUrl($font->ID)) {
+				$fonts[$font->post_name] = [
+					'name' => $font->post_title ?? __('Untitled Font', 'municipio'),
+					'type' => $this->wpService->wpCheckFiletype($url)['ext'] ?? null,
+					'url'  => str_replace($this->wpService->homeUrl(), '', $url),
+				];
+			}
+		}
+
+		return $fonts;
+	}
+
+	/**
+	 * Add font mimes
+	 *
+	 * @param array $mimes
+	 * @return array
+	 */
+	public function addFontMimes(array $mimes) : array
+	{
+		foreach ($this->allowedMimes as $ext => $mime) {
+			$mimes[$ext] = $mime;
+		}
+		return $mimes;
+	}
+
+	/**
+	 * Add uploaded fonts to stack
+	 *
+	 * @param array $fonts
+	 * @return array
+	 */
+	public function addUploadedFontsToStack(array $fonts): array 
+	{
+		foreach (self::getUploadedFonts() as $font) {
+			$fonts[$font['name'] ] = array(
+				'label' => $font['name'],
+				'stack' => $font['name'],
+			);
+		}
+		return $fonts;
+	}
+
+	/**
+	 * Get uploaded fonts css
+	 *
+	 * @return void
+	 */
+	public function getUploadedFontsCss(): void
+	{
+		foreach ( self::getUploadedFonts() as $name => $font ) {
+			echo $this->wpService->wpStripAllTags( "@font-face{font-display:swap;font-family:\"{$font['name']}\";src:url(\"{$font['url']}\");format(\"{$font['type']}\");}" );
+		}
+	}
+}

--- a/library/Customizer/FontUploads/FontUploads.php
+++ b/library/Customizer/FontUploads/FontUploads.php
@@ -36,7 +36,12 @@ class FontUploads implements Hookable {
 	 */
 	public function getUploadedFonts(): array
 	{
-		$fontAttachments = new \WP_Query( array(
+		static $fonts;
+		if ($fonts) {
+			return $fonts;
+		}
+
+		$fontAttachments = new \WP_Query(array(
 			'post_type'      => 'attachment',
 			'posts_per_page' => 50,
 			'post_status'    => ['publish', 'inherit'],
@@ -54,7 +59,7 @@ class FontUploads implements Hookable {
 				];
 			}
 		}
-
+	
 		return $fonts;
 	}
 
@@ -82,7 +87,7 @@ class FontUploads implements Hookable {
 	{
 		foreach (self::getUploadedFonts() as $font) {
 			$fonts[$font['name'] ] = array(
-				'label' => $font['name'],
+				'label' => $this->makeSlugReadable($font['name']),
 				'stack' => $font['name'],
 			);
 		}
@@ -99,5 +104,16 @@ class FontUploads implements Hookable {
 		foreach (self::getUploadedFonts() as $font) {
 			echo $this->wpService->wpStripAllTags( "@font-face{font-display:swap;font-family:\"{$font['name']}\";src:url(\"{$font['url']}\");format(\"{$font['type']}\");}" );
 		}
+	}
+
+	/**
+	 * Make slug readable
+	 *
+	 * @param string $slug
+	 * @return string
+	 */
+	private function makeSlugReadable(string $slug): string
+	{
+		return ucwords(str_replace('-', ' ', $slug));
 	}
 }

--- a/library/Customizer/FontUploads/FontUploads.php
+++ b/library/Customizer/FontUploads/FontUploads.php
@@ -96,7 +96,7 @@ class FontUploads implements Hookable {
 	 */
 	public function getUploadedFontsCss(): void
 	{
-		foreach ( self::getUploadedFonts() as $name => $font ) {
+		foreach (self::getUploadedFonts() as $font) {
 			echo $this->wpService->wpStripAllTags( "@font-face{font-display:swap;font-family:\"{$font['name']}\";src:url(\"{$font['url']}\");format(\"{$font['type']}\");}" );
 		}
 	}


### PR DESCRIPTION
This pull request introduces a new implementation for handling custom font uploads and integrates it into the customizer. The most important changes include the removal of the old font upload module, the addition of a new `FontUploads` class, and updates to the `composer.json` file to reflect these changes.

### Custom Font Uploads Implementation:

* **Removal of old font upload module**:
  - Removed the `ouun/kirki-module-fonts_upload` dependency from `composer.json`.
  - Removed the old font upload initialization code from the `init` method in `library/Customizer.php`.

* **Addition of new `FontUploads` class**:
  - Added a new `FontUploads` class in `library/Customizer/FontUploads/FontUploads.php` to handle custom font uploads, including methods for adding hooks, getting uploaded fonts, adding font MIME types, adding uploaded fonts to the stack, and generating CSS for uploaded fonts.

* **Integration of new `FontUploads` class**:
  - Updated the `init` method in `library/Customizer.php` to initialize the new `FontUploads` class and add its hooks.