### PR TITLE
feat: only allow UserGroup taxonomy on main site if multisite

### DIFF
--- a/library/App.php
+++ b/library/App.php
@@ -93,7 +93,7 @@ class App
         /*
          * Helpers
          */
-        $userGroupConfig  = new \Municipio\UserGroup\Config\UserGroupConfig();
+        $userGroupConfig  = new \Municipio\UserGroup\Config\UserGroupConfig($this->wpService);
         $userHelperConfig = new \Municipio\Helper\User\Config\UserConfig();
         $userHelper       = new \Municipio\Helper\User\User($this->wpService, $this->acfService, $userHelperConfig, $userGroupConfig);
 
@@ -391,7 +391,7 @@ class App
     private function setupLoginLogout(): void
     {
         //Needs setUser to be called before using the user object
-        $userHelper = new User($this->wpService, $this->acfService, new UserConfig(), new \Municipio\UserGroup\Config\UserGroupConfig());
+        $userHelper = new User($this->wpService, $this->acfService, new UserConfig(), new \Municipio\UserGroup\Config\UserGroupConfig($this->wpService));
 
         $filterAuthUrls = new \Municipio\Admin\Login\RelationalLoginLogourUrls($this->wpService);
         $filterAuthUrls->addHooks();
@@ -423,7 +423,7 @@ class App
      */
     private function setupUserGroupFeature(): void
     {
-        $config = new \Municipio\UserGroup\Config\UserGroupConfig();
+        $config = new \Municipio\UserGroup\Config\UserGroupConfig($this->wpService);
 
         if ($config->isEnabled() === false) {
             return;
@@ -466,7 +466,7 @@ class App
     private function setUpMiniOrangeIntegration(): void
     {
         $termHelper      = new \Municipio\Helper\Term\Term($this->wpService, $this->acfService);
-        $userGroupConfig = new \Municipio\UserGroup\Config\UserGroupConfig();
+        $userGroupConfig = new \Municipio\UserGroup\Config\UserGroupConfig($this->wpService);
         $config          = new \Municipio\Integrations\MiniOrange\Config\MiniOrangeConfig($this->wpService);
 
         if ($config->isEnabled() === false) {

--- a/library/UserGroup/Config/UserGroupConfig.php
+++ b/library/UserGroup/Config/UserGroupConfig.php
@@ -2,6 +2,9 @@
 
 namespace Municipio\UserGroup\Config;
 
+use WpService\Contracts\GetMainSiteId;
+use WpService\Contracts\IsMultisite;
+
 /**
  * User group feature configuration.
  */
@@ -10,8 +13,9 @@ class UserGroupConfig implements UserGroupConfigInterface
     /**
      * Constructor.
      */
-    public function __construct()
-    {
+    public function __construct(
+        private IsMultisite&GetMainSiteId $wpService
+    ) {
     }
 
     /**
@@ -34,5 +38,19 @@ class UserGroupConfig implements UserGroupConfigInterface
     public function getUserGroupTaxonomy(): string
     {
         return 'user_group';
+    }
+
+
+    /**
+     * Get if the user group taxonomy only should be used/stored on the main blog.
+     *
+     * @return bool|int     Integer that represents the main site id or false if not multisite.
+     */
+    public function getStoreUserGroupTaxonomyOnMainBlog(): int|false
+    {
+        if ($this->wpService->isMultisite() && $mainSiteId = $this->wpService->getMainSiteId()) {
+            return $mainSiteId;
+        }
+        return false;
     }
 }

--- a/library/UserGroup/Config/UserGroupConfig.test.php
+++ b/library/UserGroup/Config/UserGroupConfig.test.php
@@ -3,6 +3,7 @@
 namespace Municipio\UserGroup\Config;
 
 use PHPUnit\Framework\TestCase;
+use WpService\Implementations\FakeWpService;
 
 class UserGroupConfigTest extends TestCase
 {
@@ -11,7 +12,12 @@ class UserGroupConfigTest extends TestCase
      */
     public function testCanBeInstantiated()
     {
-        $userGroupConfig = new UserGroupConfig();
+        $userGroupConfig = new UserGroupConfig(
+            new FakeWpService([
+                'isMultisite'   => true,
+                'getMainSiteId' => 1
+            ])
+        );
         $this->assertInstanceOf(UserGroupConfig::class, $userGroupConfig);
     }
 
@@ -20,7 +26,12 @@ class UserGroupConfigTest extends TestCase
      */
     public function testIsEnabledReturnsTrue()
     {
-        $userGroupConfig = new UserGroupConfig();
+        $userGroupConfig = new UserGroupConfig(
+            new FakeWpService([
+                'isMultisite'   => true,
+                'getMainSiteId' => 1
+            ])
+        );
         $this->assertTrue($userGroupConfig->isEnabled());
     }
 
@@ -29,7 +40,12 @@ class UserGroupConfigTest extends TestCase
      */
     public function testGetUserGroupTaxonomyReturnsExpectedTaxonomyName()
     {
-        $userGroupConfig = new UserGroupConfig();
+        $userGroupConfig = new UserGroupConfig(
+            new FakeWpService([
+                'isMultisite'   => true,
+                'getMainSiteId' => 1
+            ])
+        );
         $this->assertEquals('user_group', $userGroupConfig->getUserGroupTaxonomy());
     }
 }

--- a/library/UserGroup/CreateUserGroupTaxonomy.test.php
+++ b/library/UserGroup/CreateUserGroupTaxonomy.test.php
@@ -43,7 +43,7 @@ class CreateUserGroupTaxonomyTest extends TestCase
      */
     public function testRegisterUserGroupTaxonomyRegistersTaxonomy()
     {
-        $wpService = new FakeWpService(['registerTaxonomy' => true, '__' => fn($string) => $string, 'registerTaxonomy' => WpMockFactory::createWpTaxonomy()]);
+        $wpService = new FakeWpService(['registerTaxonomy' => true, '__' => fn($string) => $string, 'registerTaxonomy' => WpMockFactory::createWpTaxonomy(), 'isMultisite' => true, 'getMainSiteId' => 1, 'isMainSite' => true]);
         $config    = $this->createMock(UserGroupConfigInterface::class);
         $config->method('getUserGroupTaxonomy')->willReturn('test_taxonomy');
         $createUserGroupTaxonomy = new CreateUserGroupTaxonomy($wpService, $config);
@@ -51,5 +51,20 @@ class CreateUserGroupTaxonomyTest extends TestCase
         $createUserGroupTaxonomy->registerUserGroupTaxonomy();
 
         $this->assertEquals('test_taxonomy', $wpService->methodCalls['registerTaxonomy'][0][0]);
+    }
+
+    /**
+     * @testdox registerUserGroupTaxonomy() does not register a taxonomy if is multisite but not main site
+     */
+    public function testRegisterUserGroupTaxonomyDoesNotRegisterTaxonomyIfNotMainSite()
+    {
+        $wpService = new FakeWpService(['registerTaxonomy' => true, '__' => fn($string) => $string, 'registerTaxonomy' => WpMockFactory::createWpTaxonomy(), 'isMultisite' => true, 'getMainSiteId' => 1, 'isMainSite' => false]);
+        $config    = $this->createMock(UserGroupConfigInterface::class);
+        $config->method('getUserGroupTaxonomy')->willReturn('test_taxonomy');
+        $createUserGroupTaxonomy = new CreateUserGroupTaxonomy($wpService, $config);
+
+        $createUserGroupTaxonomy->registerUserGroupTaxonomy();
+
+        $this->assertArrayNotHasKey('registerTaxonomy', $wpService->methodCalls);
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `library` directory, primarily focusing on enhancing the `UserGroupConfig` class and its integration with the `wpService`. The most important changes involve modifying the constructor to accept a `wpService` parameter, updating related methods to use this service, and adding new functionality and tests to handle multisite configurations.

### Enhancements to `UserGroupConfig`:

* [`library/UserGroup/Config/UserGroupConfig.php`](diffhunk://#diff-39ab713b35712881dbf9c2c144f4ae21a617e10eb2cc12130f469adec16fb9f2L13-R18): Updated the constructor to accept a `wpService` parameter, added a new method `getStoreUserGroupTaxonomyOnMainBlog()` to determine if the user group taxonomy should be stored on the main blog. [[1]](diffhunk://#diff-39ab713b35712881dbf9c2c144f4ae21a617e10eb2cc12130f469adec16fb9f2L13-R18) [[2]](diffhunk://#diff-39ab713b35712881dbf9c2c144f4ae21a617e10eb2cc12130f469adec16fb9f2R42-R55)

### Updates to related classes and methods:

* [`library/App.php`](diffhunk://#diff-f866e0aad6c55f4178f285d128ff5bb496ce75bdc2106be7aafbaed7b5cc1e1eL96-R96): Modified multiple methods to pass the `wpService` parameter when instantiating `UserGroupConfig`. [[1]](diffhunk://#diff-f866e0aad6c55f4178f285d128ff5bb496ce75bdc2106be7aafbaed7b5cc1e1eL96-R96) [[2]](diffhunk://#diff-f866e0aad6c55f4178f285d128ff5bb496ce75bdc2106be7aafbaed7b5cc1e1eL394-R394) [[3]](diffhunk://#diff-f866e0aad6c55f4178f285d128ff5bb496ce75bdc2106be7aafbaed7b5cc1e1eL426-R426) [[4]](diffhunk://#diff-f866e0aad6c55f4178f285d128ff5bb496ce75bdc2106be7aafbaed7b5cc1e1eL469-R469)
* [`library/UserGroup/CreateUserGroupTaxonomy.php`](diffhunk://#diff-4c80a2809c696fe1de78dcfc8422636f89ec38793eafff00a7f5c0a5b3e745b0L18-R18): Updated the constructor to accept additional `wpService` capabilities, and added a new method `shouldRegisterTaxonomy()` to check if the taxonomy should be registered based on multisite configuration. [[1]](diffhunk://#diff-4c80a2809c696fe1de78dcfc8422636f89ec38793eafff00a7f5c0a5b3e745b0L18-R18) [[2]](diffhunk://#diff-4c80a2809c696fe1de78dcfc8422636f89ec38793eafff00a7f5c0a5b3e745b0L38-R43) [[3]](diffhunk://#diff-4c80a2809c696fe1de78dcfc8422636f89ec38793eafff00a7f5c0a5b3e745b0R60-R77)

### Test updates:

* [`library/UserGroup/Config/UserGroupConfig.test.php`](diffhunk://#diff-7878d31bca608909e06c36f54048f3338220076018c6e5076d2b63dbb2810220R6): Updated tests to instantiate `UserGroupConfig` with a `FakeWpService` and added new test cases for the multisite functionality. [[1]](diffhunk://#diff-7878d31bca608909e06c36f54048f3338220076018c6e5076d2b63dbb2810220R6) [[2]](diffhunk://#diff-7878d31bca608909e06c36f54048f3338220076018c6e5076d2b63dbb2810220L14-R20) [[3]](diffhunk://#diff-7878d31bca608909e06c36f54048f3338220076018c6e5076d2b63dbb2810220L23-R34) [[4]](diffhunk://#diff-7878d31bca608909e06c36f54048f3338220076018c6e5076d2b63dbb2810220L32-R48)
* [`library/UserGroup/CreateUserGroupTaxonomy.test.php`](diffhunk://#diff-0a8aea2662e0757818545861d19455dc3b0ac34b90f2ec54b4b5bed4f840c3acL46-R46): Added new test cases to verify the behavior of `registerUserGroupTaxonomy` based on multisite and main site conditions. [[1]](diffhunk://#diff-0a8aea2662e0757818545861d19455dc3b0ac34b90f2ec54b4b5bed4f840c3acL46-R46) [[2]](diffhunk://#diff-0a8aea2662e0757818545861d19455dc3b0ac34b90f2ec54b4b5bed4f840c3acR55-R69)