### PR TITLE
fix: send user id trough miniorange get redirect url

### DIFF
--- a/library/Admin/Login/RedirectUserToGroupUrlIfIsPreferred.php
+++ b/library/Admin/Login/RedirectUserToGroupUrlIfIsPreferred.php
@@ -44,18 +44,12 @@ class RedirectUserToGroupUrlIfIsPreferred implements Hookable
             return $redirectTo;
         }
 
-        $user = $this->userHelper->getUser($userInHook);
-        if ($user != null) {
-            $perfersGroupUrl = $this->userHelper->getUserPrefersGroupUrl($user);
-            $groupUrl        = $this->userHelper->getUserGroupUrl(null, $user);
+        $userGroupRedirectUrl = $this->userHelper->getRedirectToGroupUrl($userInHook);
 
-            if ($perfersGroupUrl && $groupUrl) {
-                return $this->wpService->addQueryArg([
-                    'loggedin'     => 'true',
-                    'prefersgroup' => 'true'
-                ], $groupUrl);
-            }
+        if ($userGroupRedirectUrl != null) {
+            return $userGroupRedirectUrl;
         }
+
         return $redirectTo;
     }
 }

--- a/library/Admin/Login/RedirectUserToGroupUrlIfIsPreferred.php
+++ b/library/Admin/Login/RedirectUserToGroupUrlIfIsPreferred.php
@@ -3,9 +3,11 @@
 namespace Municipio\Admin\Login;
 
 use Municipio\HooksRegistrar\Hookable;
-use WpService\WpService;
 use Municipio\Helper\User\User;
 use WpService\Contracts\AddQueryArg;
+use WpService\Contracts\AddAction;
+use WpService\Contracts\AddFilter;
+use WpService\Contracts\IsWpError;
 
 /**
  * Redirect user to group url if user prefers group url
@@ -15,7 +17,7 @@ class RedirectUserToGroupUrlIfIsPreferred implements Hookable
     /**
      * Constructor.
      */
-    public function __construct(private WpService&AddQueryArg $wpService, private User $userHelper)
+    public function __construct(private AddAction&AddQueryArg&IsWpError&AddFilter $wpService, private User $userHelper)
     {
     }
 

--- a/library/Helper/User/Contracts/GetRedirectToGroupUrl.php
+++ b/library/Helper/User/Contracts/GetRedirectToGroupUrl.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Municipio\Helper\User\Contracts;
+
+interface GetRedirectToGroupUrl
+{
+    /**
+     * Get redirect to group url
+     *
+     * @param string $redirectTo
+     * @param string $request
+     * @param WP_User $userInHook
+     *
+     * @return string
+     */
+    public function getRedirectToGroupUrl(null|\WP_User|int $user = null): ?string;
+}

--- a/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
+++ b/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
@@ -111,15 +111,14 @@ class AllowRedirectAfterSsoLogin implements Hookable
     public function loginRequestOriginatesFromHomeUrl($location): bool
     {
         // If the location is not a valid URL, assume it is a relative path
-        if(filter_var($location, FILTER_VALIDATE_URL) === false) {
-            $location = $this->wpService->homeUrl(
-                $location
-            );
+        // and prepend a fake protocol, and domain to make it a valid and parseable URL
+        if (filter_var($location, FILTER_VALIDATE_URL) === false) {
+            $location = 'https://fakeurl.io/' . trim($location ?: '', '/');
         }
 
         // Get and normalize urls
-        $location = rtrim(parse_url($location, PHP_URL_PATH), '/');
-        $homeUrl  = rtrim(parse_url($this->wpService->homeUrl(), PHP_URL_PATH), '/');
+        $location = rtrim(parse_url($location, PHP_URL_PATH) ?? '', '/');
+        $homeUrl  = rtrim(parse_url($this->wpService->homeUrl(), PHP_URL_PATH) ?? '', '/');
 
         return $location === $homeUrl;
     }

--- a/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
+++ b/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
@@ -27,7 +27,7 @@ class AllowRedirectAfterSsoLogin implements Hookable
      */
     public function addHooks(): void
     {
-        $this->wpService->addAction('set_logged_in_cookie', [$this, 'allowRedirectAfterSsoLogin']);
+        $this->wpService->addAction('set_logged_in_cookie', [$this, 'allowRedirectAfterSsoLogin'], 10, 4);
     }
 
     /**
@@ -35,13 +35,13 @@ class AllowRedirectAfterSsoLogin implements Hookable
      *
      * @return void
      */
-    public function allowRedirectAfterSsoLogin(): void
+    public function allowRedirectAfterSsoLogin(string $loggedInCookie, int $expire, int $expiration, int $userId): void
     {
         if (!$this->doingMiniOrgangeLogin() || $this->isCustomMiniOrgangeLoginRedirectApplied()) {
             return;
         }
 
-        if (!empty($redirectUrl = $this->wpService->applyFilters(self::REDIRECT_URL_FILTER_HOOK, ''))) {
+        if (!empty($redirectUrl = $this->wpService->applyFilters(self::REDIRECT_URL_FILTER_HOOK, '', $userId))) {
             $this->setAppliedFlag();
             $this->wpService->wpSafeRedirect($redirectUrl);
         }

--- a/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
+++ b/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
@@ -31,18 +31,19 @@ class AllowRedirectAfterSsoLogin implements Hookable
 
     /**
      * Set logged in cookie filter proxy.
-     * 
+     *
      * @param string $loggedInCookie
      * @param int $expire
      * @param int $expiration
      * @param int $userId
-     * 
+     *
      * @suppress PhanUnusedVariable, IntelephenseUnusedVariable
-     * 
+     *
      * @return void
      */
-    public function setLoggedInCookieFilterProxy(string $loggedInCookie, int $expire, int $expiration, int $userId) {
-        $this->allowRedirectAfterSsoLogin($userId); 
+    public function setLoggedInCookieFilterProxy(string $loggedInCookie, int $expire, int $expiration, int $userId): void
+    {
+        $this->allowRedirectAfterSsoLogin($userId);
     }
 
     /**
@@ -56,28 +57,29 @@ class AllowRedirectAfterSsoLogin implements Hookable
             return;
         }
 
-        $redirectUrl = $this->wpService->applyFilters(self::REDIRECT_URL_FILTER_HOOK, '', $userId); 
+        $redirectUrl = $this->wpService->applyFilters(self::REDIRECT_URL_FILTER_HOOK, '', $userId);
 
         if (!empty($redirectUrl)) {
-            $redirectHandler    = function($location) use ($redirectUrl) {
+            $redirectHandler = function ($location) use ($redirectUrl) {
                 return ($location === $this->getRelayState()) ? $redirectUrl : $location;
-            }; 
+            };
             $this->wpService->addFilter('wp_redirect', $redirectHandler, 5, 1);
         }
     }
 
     /**
      * Get RelayState.
-     * 
+     *
      * @return string|null
      */
-    private function getRelayState(): ?string {
+    private function getRelayState(): ?string
+    {
         return $_POST['RelayState'] ?? null;
     }
 
     /**
      * Get SAML response.
-     * 
+     *
      * @return string|null
      */
     private function getSamlResponse(): ?string
@@ -95,4 +97,3 @@ class AllowRedirectAfterSsoLogin implements Hookable
         return $this->getSamlResponse() && $this->getRelayState();
     }
 }
- 

--- a/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
+++ b/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
@@ -29,14 +29,24 @@ class AllowRedirectAfterSsoLogin implements Hookable
         $this->wpService->addAction('set_logged_in_cookie', [$this, 'setLoggedInCookieFilterProxy'], 10, 4);
     }
 
+    /**
+     * Set logged in cookie filter proxy.
+     * 
+     * @param string $loggedInCookie
+     * @param int $expire
+     * @param int $expiration
+     * @param int $userId
+     * 
+     * @suppress PhanUnusedVariable, IntelephenseUnusedVariable
+     * 
+     * @return void
+     */
     public function setLoggedInCookieFilterProxy(string $loggedInCookie, int $expire, int $expiration, int $userId) {
         $this->allowRedirectAfterSsoLogin($userId); 
     }
 
     /**
      * Allow redirect after SSO login.
-     * 
-     * @suppress PhanUnusedVariable, IntelephenseUnusedVariable
      *
      * @return void
      */
@@ -56,11 +66,20 @@ class AllowRedirectAfterSsoLogin implements Hookable
         }
     }
 
-    /** */
-    private function getRelayState (): ?string {
+    /**
+     * Get RelayState.
+     * 
+     * @return string|null
+     */
+    private function getRelayState(): ?string {
         return $_POST['RelayState'] ?? null;
     }
 
+    /**
+     * Get SAML response.
+     * 
+     * @return string|null
+     */
     private function getSamlResponse(): ?string
     {
         return $_POST['SAMLResponse'] ?? null;

--- a/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
+++ b/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
@@ -108,9 +108,8 @@ class AllowRedirectAfterSsoLogin implements Hookable
      *
      * @return bool
      */
-    private function loginRequestOriginatesFromHomeUrl($location): bool
+    public function loginRequestOriginatesFromHomeUrl($location): bool
     {
-
         // If the location is not a valid URL, assume it is a relative path
         if(filter_var($location, FILTER_VALIDATE_URL) === false) {
             $location = $this->wpService->homeUrl(

--- a/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
+++ b/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php
@@ -32,6 +32,8 @@ class AllowRedirectAfterSsoLogin implements Hookable
 
     /**
      * Allow redirect after SSO login.
+     * 
+     * @suppress PhanUnusedVariable, IntelephenseUnusedVariable
      *
      * @return void
      */

--- a/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.test.php
+++ b/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.test.php
@@ -43,13 +43,13 @@ class AllowRedirectAfterSsoLoginTest extends TestCase
         $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
 
         $_POST = [];
-        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin();
+        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin('', 0, 0, 1);
 
         $_POST = ['SAMLResponse' => 'foo'];
-        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin();
+        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin('', 0, 0, 1);
 
         $_POST = ['RelayState' => 'bar'];
-        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin();
+        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin('', 0, 0, 1);
 
         $this->assertArrayNotHasKey('applyFilters', $wpService->methodCalls);
     }
@@ -63,7 +63,7 @@ class AllowRedirectAfterSsoLoginTest extends TestCase
         $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
 
         $_POST = ['SAMLResponse' => 'foo', 'RelayState' => 'bar'];
-        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin();
+        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin('', 0, 0, 1);
 
         $this->assertEquals($allowRedirectAfterSsoLogin::REDIRECT_URL_FILTER_HOOK, $wpService->methodCalls['applyFilters'][0][0]);
         $this->assertEquals('', $wpService->methodCalls['applyFilters'][0][1]);
@@ -78,7 +78,7 @@ class AllowRedirectAfterSsoLoginTest extends TestCase
         $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
 
         $_POST = ['SAMLResponse' => 'foo', 'RelayState' => 'bar'];
-        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin();
+        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin('', 0, 0, 1);
 
         $this->assertEquals('http://example.com', $wpService->methodCalls['wpSafeRedirect'][0][0]);
     }
@@ -92,7 +92,7 @@ class AllowRedirectAfterSsoLoginTest extends TestCase
         $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
 
         $_POST = ['SAMLResponse' => 'foo', 'RelayState' => 'bar'];
-        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin();
+        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin('', 0, 0, 1);
 
         $this->assertTrue($_POST[$allowRedirectAfterSsoLogin::APPLIED_FLAG]);
     }
@@ -106,7 +106,7 @@ class AllowRedirectAfterSsoLoginTest extends TestCase
         $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
 
         $_POST = ['SAMLResponse' => 'foo', 'RelayState' => 'bar', 'customMiniOrgangeLoginRedirectApplied' => true];
-        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin();
+        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin('', 0, 0, 1);
 
         $this->assertArrayNotHasKey('wpSafeRedirect', $wpService->methodCalls);
     }

--- a/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.test.php
+++ b/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.test.php
@@ -120,4 +120,60 @@ class AllowRedirectAfterSsoLoginTest extends TestCase
         $this->assertEquals('wp_redirect', $wpService->methodCalls['addFilter'][0][0]);
         $this->assertEquals('http://urlNotMatchingRelayStateUrl.com', $redirectHandlerResult);
     }
+
+    /**
+     * @testdox loginRequestOriginatesFromHomeUrl() returns true if relative location matches home URL
+     */
+    public function testLoginRequestOriginatesFromHomeUrlReturnsTrueForRelativeUrlMatchingHomeUrl()
+    {
+        $homeUrl      = 'https://example.com';
+        $relativePath = '/';
+
+        $wpService                  = new FakeWpService(['homeUrl' => $homeUrl]);
+        $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
+
+        $this->assertTrue($allowRedirectAfterSsoLogin->loginRequestOriginatesFromHomeUrl($relativePath));
+    }
+
+    /**
+     * @testdox loginRequestOriginatesFromHomeUrl() returns false if relative location does not match home URL
+     */
+    public function testLoginRequestOriginatesFromHomeUrlReturnsFalseForRelativeUrlNotMatchingHomeUrl()
+    {
+        $homeUrl      = 'https://example.com/somepath';
+        $relativePath = '/different-path';
+
+        $wpService                  = new FakeWpService(['homeUrl' => $homeUrl]);
+        $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
+
+        $this->assertFalse($allowRedirectAfterSsoLogin->loginRequestOriginatesFromHomeUrl($relativePath));
+    }
+
+    /**
+     * @testdox loginRequestOriginatesFromHomeUrl() returns true if absolute URL path matches home URL
+     */
+    public function testLoginRequestOriginatesFromHomeUrlReturnsTrueForAbsoluteUrlMatchingHomeUrl()
+    {
+        $homeUrl     = 'https://example.com';
+        $absoluteUrl = 'https://example.com/';
+
+        $wpService                  = new FakeWpService(['homeUrl' => $homeUrl]);
+        $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
+
+        $this->assertTrue($allowRedirectAfterSsoLogin->loginRequestOriginatesFromHomeUrl($absoluteUrl));
+    }
+
+    /**
+     * @testdox loginRequestOriginatesFromHomeUrl() returns false if absolute URL path does not match home URL
+     */
+    public function testLoginRequestOriginatesFromHomeUrlReturnsFalseForAbsoluteUrlNotMatchingHomeUrl()
+    {
+        $homeUrl     = 'https://example.com';
+        $absoluteUrl = 'https://example.com/different-path';
+
+        $wpService                  = new FakeWpService(['homeUrl' => $homeUrl]);
+        $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
+
+        $this->assertFalse($allowRedirectAfterSsoLogin->loginRequestOriginatesFromHomeUrl($absoluteUrl));
+    }
 }

--- a/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.test.php
+++ b/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.test.php
@@ -81,7 +81,9 @@ class AllowRedirectAfterSsoLoginTest extends TestCase
             'addAction'      => true,
             'applyFilters'   => $redirectTo,
             'addFilter'      => true,
-            'wpSafeRedirect' => true]);
+            'wpSafeRedirect' => true,
+            'homeUrl'        => 'https://example.com/'
+        ]);
 
         $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
 
@@ -105,7 +107,9 @@ class AllowRedirectAfterSsoLoginTest extends TestCase
             'addAction'      => true,
             'applyFilters'   => $redirectTo,
             'addFilter'      => true,
-            'wpSafeRedirect' => true]);
+            'wpSafeRedirect' => true,
+            'homeUrl'        => 'https://example.com/'
+        ]);
 
         $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
 

--- a/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.test.php
+++ b/library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.test.php
@@ -70,25 +70,6 @@ class AllowRedirectAfterSsoLoginTest extends TestCase
     }
 
     /**
-     * @testdox allowRedirectAfterSsoLogin() does not attempt to redirect if redirection flag is already set
-     */
-    public function testAllowRedirectAfterSsoLoginDoesNotAttemptToRedirectIfRedirectionFlagIsAlreadySet()
-    {
-        $wpService = new FakeWpService([
-            'addAction'      => true,
-            'applyFilters'   => 'http://example.com',
-            'addFilter'      => true,
-            'wpSafeRedirect' => true]);
-
-        $allowRedirectAfterSsoLogin = new AllowRedirectAfterSsoLogin($wpService);
-
-        $_POST = ['SAMLResponse' => 'foo', 'RelayState' => 'bar', 'customMiniOrgangeLoginRedirectApplied' => true];
-        $allowRedirectAfterSsoLogin->allowRedirectAfterSsoLogin(1);
-
-        $this->assertArrayNotHasKey('wpSafeRedirect', $wpService->methodCalls);
-    }
-
-    /**
      * @testdox allowRedirectAfterSsoLogin() redirect handler is applied to wp_redirect filter
      */
     public function testAllowRedirectAfterSsoLoginRedirectsToUrlIfFilterIsSet()

--- a/library/UserGroup/RedirectToUserGroupUrlAfterSsoLogin.php
+++ b/library/UserGroup/RedirectToUserGroupUrlAfterSsoLogin.php
@@ -5,7 +5,7 @@ namespace Municipio\UserGroup;
 use Municipio\Helper\User\Contracts\GetUserGroupUrl;
 use Municipio\HooksRegistrar\Hookable;
 use WpService\Contracts\AddFilter;
-use Municipio\Admin\Login\RedirectUserToGroupUrlIfIsPreferred; 
+use Municipio\Helper\User\Contracts\GetRedirectToGroupUrl;
 
 /**
  * Redirect to user group URL after SSO login.
@@ -15,7 +15,7 @@ class RedirectToUserGroupUrlAfterSsoLogin implements Hookable
     /**
      * Constructor.
      */
-    public function __construct(private GetUserGroupUrl $userHelper, private AddFilter $wpService)
+    public function __construct(private GetUserGroupUrl&GetRedirectToGroupUrl $userHelper, private AddFilter $wpService)
     {
     }
 
@@ -35,10 +35,11 @@ class RedirectToUserGroupUrlAfterSsoLogin implements Hookable
      */
     public function getRedirectUrl(string $redirectTo, int|null $userId = null): string
     {
-        $redirectTo = (new RedirectUserToGroupUrlIfIsPreferred(
-            $this->wpService,
-            $this->userHelper
-        ))->redirectToGroupUrl($redirectTo, '', $userId);
+        $userGroupRedirectUrl = $this->userHelper->getRedirectToGroupUrl($userId);
+
+        if ($userGroupRedirectUrl != null) {
+            return $userGroupRedirectUrl;
+        }
 
         return $redirectTo;
     }

--- a/library/UserGroup/RedirectToUserGroupUrlAfterSsoLogin.php
+++ b/library/UserGroup/RedirectToUserGroupUrlAfterSsoLogin.php
@@ -5,6 +5,7 @@ namespace Municipio\UserGroup;
 use Municipio\Helper\User\Contracts\GetUserGroupUrl;
 use Municipio\HooksRegistrar\Hookable;
 use WpService\Contracts\AddFilter;
+use Municipio\Admin\Login\RedirectUserToGroupUrlIfIsPreferred; 
 
 /**
  * Redirect to user group URL after SSO login.
@@ -32,14 +33,13 @@ class RedirectToUserGroupUrlAfterSsoLogin implements Hookable
      * @param string $url
      * @return string
      */
-    public function getRedirectUrl(string $url, int|null $userId = null): string
+    public function getRedirectUrl(string $redirectTo, int|null $userId = null): string
     {
-        $userGroupUrl = $this->userHelper->getUserGroupUrl(null, $userId);
-        
-        if (!$userGroupUrl) {
-            return $url;
-        }
+        $redirectTo = (new RedirectUserToGroupUrlIfIsPreferred(
+            $this->wpService,
+            $this->userHelper
+        ))->redirectToGroupUrl($redirectTo, '', $userId);
 
-        return $userGroupUrl;
+        return $redirectTo;
     }
 }

--- a/library/UserGroup/RedirectToUserGroupUrlAfterSsoLogin.php
+++ b/library/UserGroup/RedirectToUserGroupUrlAfterSsoLogin.php
@@ -23,7 +23,7 @@ class RedirectToUserGroupUrlAfterSsoLogin implements Hookable
      */
     public function addHooks(): void
     {
-        $this->wpService->addFilter(\Municipio\Integrations\MiniOrange\AllowRedirectAfterSsoLogin::REDIRECT_URL_FILTER_HOOK, [$this, 'getRedirectUrl'], 10, 1);
+        $this->wpService->addFilter(\Municipio\Integrations\MiniOrange\AllowRedirectAfterSsoLogin::REDIRECT_URL_FILTER_HOOK, [$this, 'getRedirectUrl'], 10, 2);
     }
 
     /**
@@ -32,7 +32,7 @@ class RedirectToUserGroupUrlAfterSsoLogin implements Hookable
      * @param string $url
      * @return string
      */
-    public function getRedirectUrl(string $url): string
+    public function getRedirectUrl(string $url, int|null $userId = null): string
     {
         if (!$this->userHelper->getUserGroupUrl()) {
             return $url;

--- a/library/UserGroup/RedirectToUserGroupUrlAfterSsoLogin.php
+++ b/library/UserGroup/RedirectToUserGroupUrlAfterSsoLogin.php
@@ -34,10 +34,12 @@ class RedirectToUserGroupUrlAfterSsoLogin implements Hookable
      */
     public function getRedirectUrl(string $url, int|null $userId = null): string
     {
-        if (!$this->userHelper->getUserGroupUrl()) {
+        $userGroupUrl = $this->userHelper->getUserGroupUrl(null, $userId);
+        
+        if (!$userGroupUrl) {
             return $url;
         }
 
-        return $this->userHelper->getUserGroupUrl();
+        return $userGroupUrl;
     }
 }

--- a/library/UserGroup/RedirectToUserGroupUrlAfterSsoLogin.test.php
+++ b/library/UserGroup/RedirectToUserGroupUrlAfterSsoLogin.test.php
@@ -3,6 +3,7 @@
 namespace Municipio\UserGroup;
 
 use Municipio\Helper\User\Contracts\GetUserGroupUrl;
+use Municipio\Helper\User\User;
 use PHPUnit\Framework\TestCase;
 use WpService\Implementations\FakeWpService;
 
@@ -13,7 +14,7 @@ class RedirectToUserGroupUrlAfterSsoLoginTest extends TestCase
      */
     public function testCanBeInstantiated()
     {
-        $userHelper = $this->createMock(GetUserGroupUrl::class);
+        $userHelper = $this->createMock(User::class);
         $sut        = new RedirectToUserGroupUrlAfterSsoLogin($userHelper, new FakeWpService());
         $this->assertInstanceOf(RedirectToUserGroupUrlAfterSsoLogin::class, $sut);
     }
@@ -23,7 +24,7 @@ class RedirectToUserGroupUrlAfterSsoLoginTest extends TestCase
      */
     public function testAddHooksAddsFilterToRedirectUrl()
     {
-        $userHelper = $this->createMock(GetUserGroupUrl::class);
+        $userHelper = $this->createMock(User::class);
         $wpService  = new FakeWpService(['addFilter' => true]);
         $sut        = new RedirectToUserGroupUrlAfterSsoLogin($userHelper, $wpService);
 
@@ -40,8 +41,8 @@ class RedirectToUserGroupUrlAfterSsoLoginTest extends TestCase
      */
     public function testGetRedirectUrlReturnsUrlFromGetUserGroupUrl()
     {
-        $userHelper = $this->createMock(GetUserGroupUrl::class);
-        $userHelper->method('getUserGroupUrl')->willReturn('http://example.com');
+        $userHelper = $this->createMock(User::class);
+        $userHelper->method('getRedirectToGroupUrl')->willReturn('http://example.com');
         $sut = new RedirectToUserGroupUrlAfterSsoLogin($userHelper, new FakeWpService());
         $this->assertEquals('http://example.com', $sut->getRedirectUrl('http://example.org'));
     }
@@ -51,8 +52,8 @@ class RedirectToUserGroupUrlAfterSsoLoginTest extends TestCase
      */
     public function testGetRedirectUrlReturnsOriginalUrlIfGetUserGroupUrlReturnsNull()
     {
-        $userHelper = $this->createMock(GetUserGroupUrl::class);
-        $userHelper->method('getUserGroupUrl')->willReturn(null);
+        $userHelper = $this->createMock(User::class);
+        $userHelper->method('getRedirectToGroupUrl')->willReturn(null);
         $sut = new RedirectToUserGroupUrlAfterSsoLogin($userHelper, new FakeWpService());
         $this->assertEquals('http://example.org', $sut->getRedirectUrl('http://example.org'));
     }


### PR DESCRIPTION
This pull request includes changes to improve the handling of redirects after SSO login by adding support for user-specific redirects and enhancing type safety. The most important changes include updating method signatures to accept additional parameters and modifying filter and action hooks to pass these parameters.

Enhancements to redirect handling:

* [`library/Integrations/MiniOrange/AllowRedirectAfterSsoLogin.php`](diffhunk://#diff-ab40ed2c511af58c876f70b01426bc022e0bc893af8e283ec4756ef9c56d5456L30-R46): Updated the `allowRedirectAfterSsoLogin` method to accept additional parameters and modified the `addAction` call to pass these parameters. Added suppression annotations for unused variables.

* [`library/UserGroup/RedirectToUserGroupUrlAfterSsoLogin.php`](diffhunk://#diff-95a48fd074d11b00b72cc6773715e4bc5a2b74e85ab09dfef57ef153ed87ac30L26-R26): Updated the `getRedirectUrl` method to accept an optional `userId` parameter and modified the `addFilter` call to pass this parameter. [[1]](diffhunk://#diff-95a48fd074d11b00b72cc6773715e4bc5a2b74e85ab09dfef57ef153ed87ac30L26-R26) [[2]](diffhunk://#diff-95a48fd074d11b00b72cc6773715e4bc5a2b74e85ab09dfef57ef153ed87ac30L35-R43)