### PR TITLE
feat: replace permalinks to posts that are redirected.

### DIFF
--- a/library/App.php
+++ b/library/App.php
@@ -180,6 +180,9 @@ class App
             $decorator = new \Municipio\PostDecorators\ApplyProjectTerms($decorator);
             $decorator = new \Municipio\PostDecorators\ApplyProjectProgress($this->wpService, $decorator);
 
+            //Seo Redirect
+            $decorator = new \Municipio\PostDecorators\ApplySeoRedirect($this->wpService, $decorator);
+
             return $decorator->apply($post);
         }, 10, 1);
 

--- a/library/PostDecorators/ApplySeoRedirect.php
+++ b/library/PostDecorators/ApplySeoRedirect.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Municipio\PostDecorators;
+
+use WpService\Contracts\GetPostMeta;
+
+/**
+ * ApplySeoRedirect class.
+ *
+ * This class is a PostDecorator implementation that replaces the permalink to the redirect URL if a redirect is set.
+ */
+class ApplySeoRedirect implements PostDecorator
+{
+    /**
+     * @param GetPostMeta $wpService The WordPress service for retrieving post meta.
+     * @param PostDecorator|null $inner The inner post decorator. Defaults to a NullDecorator.
+     */
+    public function __construct(private GetPostMeta $wpService, private ?PostDecorator $inner = new NullDecorator())
+    {
+    }
+
+    /**
+     * Applies the SEO redirect to the post.
+     *
+     * @param \WP_Post $post The post to replace the url for.
+     * @return \WP_Post The post with permalink replaced.
+     */
+    public function apply(\WP_Post $post): \WP_Post
+    {
+        $post = $this->inner->apply($post);
+
+        $seoRedirectMetaUrl = $this->wpService->getPostMeta($post->ID, 'redirect', true);
+
+        if(filter_var($seoRedirectMetaUrl, FILTER_VALIDATE_URL)) {
+          $post->permalink = $seoRedirectMetaUrl;
+        }
+
+        return $post;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new SEO redirect feature to the `library` module. The main changes involve adding a new post decorator class and integrating it into the existing post decoration process.

### SEO Redirect Feature:

* [`library/App.php`](diffhunk://#diff-f866e0aad6c55f4178f285d128ff5bb496ce75bdc2106be7aafbaed7b5cc1e1eR183-R185): Added the `ApplySeoRedirect` post decorator to the post decoration chain in the `__construct` method.
* [`library/PostDecorators/ApplySeoRedirect.php`](diffhunk://#diff-3e60727d5021908ad8ecae0eeda80155e23aecafb9270f6fbf55f4e8aa61aab6R1-R40): Created the `ApplySeoRedirect` class, which implements the `PostDecorator` interface. This class replaces the permalink of a post with a redirect URL if one is set.