### PR TITLE
fix: allow setting props on PostObject

### DIFF
--- a/library/PostObject/Decorators/BackwardsCompatiblePostObject.php
+++ b/library/PostObject/Decorators/BackwardsCompatiblePostObject.php
@@ -19,7 +19,7 @@ class BackwardsCompatiblePostObject implements PostObjectInterface
     /**
      * Constructor.
      */
-    public function __construct(private PostObjectInterface $postObject, object $legacyPost)
+    public function __construct(private PostObjectInterface $postObject, private object $legacyPost)
     {
         foreach ($legacyPost as $key => $value) {
             if (array_key_exists($key, self::PROPERTY_TO_METHOD_MAP)) {
@@ -43,6 +43,21 @@ class BackwardsCompatiblePostObject implements PostObjectInterface
         if (array_key_exists($name, self::PROPERTY_TO_METHOD_MAP)) {
             return $this->{self::PROPERTY_TO_METHOD_MAP[$name]}();
         }
+    }
+
+    /**
+     * Magic setter.
+     *
+     * @param string $name
+     * @param mixed $value
+     */
+    public function __set($name, $value)
+    {
+        if (array_key_exists($name, self::PROPERTY_TO_METHOD_MAP)) {
+            return;
+        }
+
+        $this->{$name} = $value;
     }
 
     /**

--- a/library/PostObject/Decorators/BackwardsCompatiblePostObject.test.php
+++ b/library/PostObject/Decorators/BackwardsCompatiblePostObject.test.php
@@ -62,6 +62,18 @@ class BackwardsCompatiblePostObjectTest extends TestCase
         $this->assertEquals('http://example.com', $result->permalink);
     }
 
+    /**
+     * @testdox does not allow setting permalink via magic setter
+     */
+    public function testDoesNotAllowSettingPermalinkViaMagicSetter()
+    {
+        $result = new BackwardsCompatiblePostObject($this->getPostObject(), (object) []);
+
+        $result->permalink = 'http://example.com';
+
+        $this->assertNotEquals('http://example.com', @$result->permalink);
+    }
+
     private function getPostObject(): PostObjectInterface|MockObject
     {
         return $this->createMock(PostObjectInterface::class);


### PR DESCRIPTION
Allow setting other class properties than `permalink` on PostObject when using BackwardsCompatiblePostObject.