### PR TITLE
fix: remove check if function exists in acf service.

### DIFF
--- a/library/CommonFieldGroups/FilterGetFieldToRetriveCommonValues.php
+++ b/library/CommonFieldGroups/FilterGetFieldToRetriveCommonValues.php
@@ -55,11 +55,7 @@ class FilterGetFieldToRetriveCommonValues implements Hookable
      */
     public function getFieldKeysForGroup(string $groupId): array
     {
-        //TODO: Remove when acf function is delcared in service
-        $func = $this->acfService->acfGetFields ?? 'acf_get_fields';
-
-        // Call the function and return the field keys
-        return array_map(fn($field) => $field['key'], $func($groupId) ?: []);
+        return array_map(fn($field) => $field['key'], $this->acfService->acfGetFields($groupId) ?: []);
     }
 
     /**


### PR DESCRIPTION
This pull request includes a change to the `getFieldKeysForGroup` method in the `FilterGetFieldToRetriveCommonValues.php` file. The change simplifies the method by removing the conditional function call and directly using the `acfGetFields` method from the `acfService`.

Simplification of method:

* [`library/CommonFieldGroups/FilterGetFieldToRetriveCommonValues.php`](diffhunk://#diff-ffbce9a336f662509771c6ca8d8c9b637b852d7478360cb2d2b57f2ce8c171eeL58-R58): Removed the conditional function call to `acf_get_fields` and directly used the `acfGetFields` method from `acfService` in the `getFieldKeysForGroup` method.