### PR TITLE
feat: add nonce verification for user group visibility updates

### DIFF
--- a/library/UserGroup/AddSelectUserGroupForPrivatePost.php
+++ b/library/UserGroup/AddSelectUserGroupForPrivatePost.php
@@ -71,13 +71,13 @@ class AddSelectUserGroupForPrivatePost implements Hookable
             return;
         }
 
-        $metaKey = $this->userGroupRestrictionConfig->getUserGroupVisibilityMetaKey();
-
-        $this->wpService->deletePostMeta($postId, $metaKey);
-
         if ($this->wpService->checkAdminReferer(self::NONCE_ACTION, self::NONCE_NAME) === false) {
             return;
         }
+
+        $metaKey = $this->userGroupRestrictionConfig->getUserGroupVisibilityMetaKey();
+
+        $this->wpService->deletePostMeta($postId, $metaKey);
 
         // phpcs:ignore WordPress.Security.NonceVerification.Missing
         if (empty($_POST[$metaKey])) {


### PR DESCRIPTION
This pull request includes several changes to the `library/UserGroup/AddSelectUserGroupForPrivatePost.php` file to enhance security and functionality. The most important changes involve adding nonce verification to improve security and updating the constructor to include new service dependencies.

Security improvements:

* Added `WpService\Contracts\CheckAdminReferer` and `WpService\Contracts\WpNonceField` to handle nonce verification and field creation.
* Introduced constants `NONCE_ACTION` and `NONCE_NAME` for nonce handling in the `AddSelectUserGroupForPrivatePost` class.
* Implemented nonce verification in the `saveUserVisibilitySelect` method to ensure requests are valid.
* Added a nonce field in the `renderPrivateVisibilityList` method to include nonce data in forms.

Constructor update:

* Updated the constructor to include `WpNonceField` and `CheckAdminReferer` as dependencies in the `wpService` parameter.