### PR TITLE
fix: change action to edit_post for sticky checkbox and visibility select

### DIFF
--- a/library/StickyPost/AddStickyCheckboxForPost.php
+++ b/library/StickyPost/AddStickyCheckboxForPost.php
@@ -46,7 +46,7 @@ class AddStickyCheckboxForPost implements Hookable
     {
         $this->wpService->addAction('post_submitbox_misc_actions', array($this, 'addStickyCheckbox'), 10);
         $this->wpService->addAction('attachment_submitbox_misc_actions', array($this, 'addStickyCheckbox'), 10);
-        $this->wpService->addAction('save_post', array($this, 'saveStickyCheckboxValue'));
+        $this->wpService->addAction('edit_post', array($this, 'saveStickyCheckboxValue'));
         $this->wpService->addAction('edit_attachment', array($this, 'saveStickyCheckboxValue'));
     }
 

--- a/library/UserGroup/AddSelectUserGroupForPrivatePost.php
+++ b/library/UserGroup/AddSelectUserGroupForPrivatePost.php
@@ -51,7 +51,7 @@ class AddSelectUserGroupForPrivatePost implements Hookable
     {
         $this->wpService->addAction('post_submitbox_misc_actions', array($this, 'addUserVisibilitySelect'), 10);
         $this->wpService->addAction('attachment_submitbox_misc_actions', array($this, 'addUserVisibilitySelect'), 10);
-        $this->wpService->addAction('save_post', array($this, 'saveUserVisibilitySelect'));
+        $this->wpService->addAction('edit_post', array($this, 'saveUserVisibilitySelect'));
         $this->wpService->addAction('edit_attachment', array($this, 'saveUserVisibilitySelect'));
     }
 


### PR DESCRIPTION
This pull request includes changes to the `addHooks` method in two files to ensure that the `saveStickyCheckboxValue` and `saveUserVisibilitySelect` actions are triggered correctly. The changes involve replacing the `save_post` action with the `edit_post` action.

Changes to action hooks:

* [`library/StickyPost/AddStickyCheckboxForPost.php`](diffhunk://#diff-ad11d4b84083e449809634a875cad2fc711dc1c3095121df8e620c0901435d7bL49-R49): Changed the action hook from `save_post` to `edit_post` for the `saveStickyCheckboxValue` method to ensure it is triggered during the edit post process.
* [`library/UserGroup/AddSelectUserGroupForPrivatePost.php`](diffhunk://#diff-09513c2dbc86f5664644c15367ca4de970372bcecaf3d92734bca3d7a53b1fb6L54-R54): Changed the action hook from `save_post` to `edit_post` for the `saveUserVisibilitySelect` method to ensure it is triggered during the edit post process.