### PR TITLE
fix: do not check admin referer, verify nonce.

### DIFF
--- a/library/StickyPost/AddStickyCheckboxForPost.php
+++ b/library/StickyPost/AddStickyCheckboxForPost.php
@@ -6,7 +6,7 @@ use Municipio\HooksRegistrar\Hookable;
 use Municipio\StickyPost\Helper\GetStickyOption as GetStickyOptionHelper;
 use WpService\Contracts\__;
 use WpService\Contracts\AddAction;
-use WpService\Contracts\CheckAdminReferer;
+use WpService\Contracts\WpVerifyNonce;
 use WpService\Contracts\Checked;
 use WpService\Contracts\CurrentUserCan;
 use WpService\Contracts\GetOption;
@@ -31,7 +31,7 @@ class AddStickyCheckboxForPost implements Hookable
      */
     public function __construct(
         private GetStickyOptionHelper $getStickyOptionHelper,
-        private AddAction&CurrentUserCan&Checked&__&GetOption&UpdateOption&GetPostType&WpNonceField&CheckAdminReferer&GetPostTypeObject&UseBlockEditorForPost $wpService
+        private AddAction&CurrentUserCan&Checked&__&GetOption&UpdateOption&GetPostType&WpNonceField&WpVerifyNonce&GetPostTypeObject&UseBlockEditorForPost $wpService
     ) {
     }
 
@@ -66,7 +66,7 @@ class AddStickyCheckboxForPost implements Hookable
             return;
         }
 
-        if ($this->wpService->checkAdminReferer(self::NONCE_ACTION, self::NONCE_NAME) === false) {
+        if (!$this->wpService->wpVerifyNonce(self::NONCE_ACTION, self::NONCE_NAME)) {
             return;
         }
 

--- a/library/UserGroup/AddSelectUserGroupForPrivatePost.php
+++ b/library/UserGroup/AddSelectUserGroupForPrivatePost.php
@@ -14,9 +14,9 @@ use WpService\Contracts\SanitizeTextField;
 use Municipio\Admin\Private\Config\UserGroupRestrictionConfig;
 use Municipio\Helper\User\Config\UserConfig as UserHelperConfig;
 use Municipio\Helper\User\GetUserGroupTerms;
-use WpService\Contracts\CheckAdminReferer;
 use WpService\Contracts\UseBlockEditorForPost;
 use WpService\Contracts\WpNonceField;
+use WpService\Contracts\WpVerifyNonce;
 
 /**
  * Represents a UserGroupSelector class.
@@ -32,7 +32,7 @@ class AddSelectUserGroupForPrivatePost implements Hookable
      * Constructor for the UserGroupSelector class.
      */
     public function __construct(
-        private AddAction&DeletePostMeta&AddPostMeta&GetPostMeta&GetTerms&SanitizeTextField&CurrentUserCan&Checked&WpNonceField&CheckAdminReferer&UseBlockEditorForPost $wpService,
+        private AddAction&DeletePostMeta&AddPostMeta&GetPostMeta&GetTerms&SanitizeTextField&CurrentUserCan&Checked&WpNonceField&WpVerifyNonce&UseBlockEditorForPost $wpService,
         private string $userGroupTaxonomyName,
         private UserHelperConfig $userHelperConfig,
         private UserGroupRestrictionConfig $userGroupRestrictionConfig,
@@ -76,7 +76,7 @@ class AddSelectUserGroupForPrivatePost implements Hookable
             return;
         }
 
-        if ($this->wpService->checkAdminReferer(self::NONCE_ACTION, self::NONCE_NAME) === false) {
+        if (!$this->wpService->wpVerifyNonce(self::NONCE_ACTION, self::NONCE_NAME)) {
             return;
         }
 


### PR DESCRIPTION
This pull request involves several changes to replace the `CheckAdminReferer` contract with the `WpVerifyNonce` contract across different files. The changes ensure a more consistent and secure way of verifying nonces within the codebase.

### Changes to `library/StickyPost/AddStickyCheckboxForPost.php`:

* Replaced `CheckAdminReferer` with `WpVerifyNonce` in the list of used contracts.
* Updated the constructor to use `WpVerifyNonce` instead of `CheckAdminReferer` in the `$wpService` parameter.
* Modified the `saveStickyCheckboxValue` method to use `wpVerifyNonce` instead of `checkAdminReferer`.

### Changes to `library/UserGroup/AddSelectUserGroupForPrivatePost.php`:

* Replaced `CheckAdminReferer` with `WpVerifyNonce` in the list of used contracts.
* Updated the constructor to use `WpVerifyNonce` instead of `CheckAdminReferer` in the `$wpService` parameter.
* Modified the `saveUserVisibilitySelect` method to use `wpVerifyNonce` instead of `checkAdminReferer`.