### PR TITLE
fix: resolves issues with archive lists and dates

### DIFF
--- a/library/Controller/Archive.php
+++ b/library/Controller/Archive.php
@@ -627,7 +627,7 @@ class Archive extends \Municipio\Controller\BaseController
                         'href'    => WP::getPermalink($post->id),
                         'columns' => [
                             $post->postTitle,
-                            $post->post_date = wp_date(get_option( 'date_format' ), $post->getArchiveDateTimestamp())
+                            $post->post_date = wp_date(get_option('date_format'), $post->getArchiveDateTimestamp())
                         ]
                     ];
 
@@ -657,7 +657,7 @@ class Archive extends \Municipio\Controller\BaseController
                     continue;
                 }
 
-                $termNames = array_map(function($term) {    
+                $termNames = array_map(function ($term) {
                     if ($timestamp = strtotime($term->name ?? '')) {
                         return wp_date(get_option('date_format'), $timestamp);
                     }

--- a/library/Controller/Archive.php
+++ b/library/Controller/Archive.php
@@ -627,7 +627,7 @@ class Archive extends \Municipio\Controller\BaseController
                         'href'    => WP::getPermalink($post->id),
                         'columns' => [
                             $post->postTitle,
-                            $post->post_date = $post->getArchiveDateTimestamp()
+                            $post->post_date = wp_date(get_option( 'date_format' ), $post->getArchiveDateTimestamp())
                         ]
                     ];
 
@@ -657,8 +657,12 @@ class Archive extends \Municipio\Controller\BaseController
                     continue;
                 }
 
-                $termNames = array_map(fn($term) => $term->name, $terms);
-                array_unshift($termNames, $post->getArchiveDateTimestamp() ?? '');
+                $termNames = array_map(function($term) {    
+                    if ($timestamp = strtotime($term->name ?? '')) {
+                        return wp_date(get_option('date_format'), $timestamp);
+                    }
+                    return $term->name;
+                }, $terms);
 
                 $preparedPosts['items'][count($preparedPosts['items']) - 1]['columns'][$taxonomy] = join(', ', $termNames);
             }


### PR DESCRIPTION
This pull request includes changes to the `library/Controller/Archive.php` file to enhance the date formatting for posts and taxonomy terms. The most important changes include modifying the date format in the `getListItems` and `prepareTaxonomyColumns` functions.

Improvements to date formatting:

* [`library/Controller/Archive.php`](diffhunk://#diff-c406e1b5d78eacda466d38f1df2f163898d4bf85db6b4020b9c88b8c36732bbbL630-R630): Updated the `getListItems` function to use `wp_date` with the WordPress date format option for `post_date`.
* [`library/Controller/Archive.php`](diffhunk://#diff-c406e1b5d78eacda466d38f1df2f163898d4bf85db6b4020b9c88b8c36732bbbL660-R665): Modified the `prepareTaxonomyColumns` function to format term names as dates when possible using `wp_date` and the WordPress date format option.