### PR TITLE
feat: enables tidy html that cleans html output to comply with current standards

### DIFF
--- a/library/Template.php
+++ b/library/Template.php
@@ -300,12 +300,12 @@ class Template
                 $tidy = new \tidy();
 
                 $tidy->parseString($markup, [
-                    'indent'                => true,
-                    'output-xhtml'          => false,
-                    'wrap'                  => PHP_INT_MAX,
-                    'doctype'               => 'html5',
-                    'drop-empty-elements'   => false,
-                    'drop-empty-paras'      => false
+                    'indent'              => true,
+                    'output-xhtml'        => false,
+                    'wrap'                => PHP_INT_MAX,
+                    'doctype'             => 'html5',
+                    'drop-empty-elements' => false,
+                    'drop-empty-paras'    => false
                 ], 'utf8');
 
                 $tidy->cleanRepair();

--- a/library/Template.php
+++ b/library/Template.php
@@ -310,8 +310,10 @@ class Template
 
                 $tidy->cleanRepair();
 
+                //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                 echo $tidy;
             } else {
+                //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                 echo $markup;
             }
         } catch (\Throwable $e) {

--- a/library/Template.php
+++ b/library/Template.php
@@ -300,10 +300,12 @@ class Template
                 $tidy = new \tidy();
 
                 $tidy->parseString($markup, [
-                    'indent'       => true,
-                    'output-xhtml' => false,
-                    'wrap'         => PHP_INT_MAX,
-                    'doctype'      => 'html5'
+                    'indent'                => true,
+                    'output-xhtml'          => false,
+                    'wrap'                  => PHP_INT_MAX,
+                    'doctype'               => 'html5',
+                    'drop-empty-elements'   => false,
+                    'drop-empty-paras'      => false
                 ], 'utf8');
 
                 $tidy->cleanRepair();

--- a/library/Template.php
+++ b/library/Template.php
@@ -295,17 +295,15 @@ class Template
                 ->makeView($view, array_merge($data, array('errorMessage' => false)), [], $this->viewPaths)
                 ->render();
 
-            // Adds the option to make html more readable.
-            // This is a option that is intended for permanent
-            // use. But cannot be implemented due to some html
-            // issues.
-            if (class_exists('tidy') && isset($_GET['tidy'])) {
+            // Adds the option to make html more readable and fixes some validation issues (like /> in void elements)
+            if (class_exists('tidy') && (!defined('DISABLE_HTML_TIDY') || constant('DISABLE_HTML_TIDY') !== true)) {
                 $tidy = new \tidy();
 
                 $tidy->parseString($markup, [
                     'indent'       => true,
                     'output-xhtml' => false,
-                    'wrap'         => PHP_INT_MAX
+                    'wrap'         => PHP_INT_MAX,
+                    'doctype'      => 'html5'
                 ], 'utf8');
 
                 $tidy->cleanRepair();


### PR DESCRIPTION
This pull request includes a change to the `public function renderView($view, $data = array())` method in the `library/Template.php` file. The change modifies the HTML tidy functionality to improve readability and fix validation issues. This feature should be enabled in order to improve html output that are not adjustable by code; for example <br/> tags origin from tinymce editor, and other. 

Improvements to HTML tidy functionality:

* [`library/Template.php`](diffhunk://#diff-7a810c83f9eec229237054e7bf7bd4b18443a6e6246f1a089a3e0d02889cbc3dL298-R306): Updated the condition to enable HTML tidy only if the `DISABLE_HTML_TIDY` constant is not defined or set to false. Additionally, added the `doctype` option set to 'html5' to the tidy configuration.

You may use DISABLE_HTML_TIDY set to TRUE in order to disable this feature. 