### PR TITLE
fix: include port in sanitized URL if not default

### DIFF
--- a/library/Content/Images.php
+++ b/library/Content/Images.php
@@ -249,6 +249,7 @@ class Images
         // Reconstruct the URL without the query part
         $sanitizedUrl  = isset($parsedUrl['scheme']) ? $parsedUrl['scheme'] . '://' : '';
         $sanitizedUrl .= isset($parsedUrl['host']) ? $parsedUrl['host'] : '';
+        $sanitizedUrl .= isset($parsedUrl['port']) && !in_array($parsedUrl['port'], [80, 443]) ? ':' . $parsedUrl['port'] : '';
         $sanitizedUrl .= isset($parsedUrl['path']) ? $parsedUrl['path'] : '';
 
         // Remove the pixelsize

--- a/library/Content/Images.php
+++ b/library/Content/Images.php
@@ -5,8 +5,14 @@ namespace Municipio\Content;
 use Municipio\Integrations\Component\ImageResolver;
 use ComponentLibrary\Integrations\Image\Image as ImageComponentContract;
 
+/**
+ * Class Images
+ */
 class Images
 {
+    /**
+     * Images constructor.
+     */
     public function __construct()
     {
         add_filter('the_content', array($this, 'normalizeImages'), 11);


### PR DESCRIPTION
This pull request focuses on enhancing the URL sanitization process in the `library/Content/Images.php` file. The most important change involves updating the `sanitizeRequestUrl` function to include the port number in the URL reconstruction if it is not the default HTTP or HTTPS port.

Improvements to URL sanitization:

* [`library/Content/Images.php`](diffhunk://#diff-4d0da5f359168108b5b8307b265f8f3995c1a24e39ed8561730a18d79979ca64R252): Modified the `sanitizeRequestUrl` function to append the port number to the URL if it is not 80 or 443. This ensures that non-standard port numbers are preserved in the sanitized URL.