### PR TITLE
fix: external content cron sync error

### DIFF
--- a/library/ExternalContent/SyncHandler/SyncHandler.php
+++ b/library/ExternalContent/SyncHandler/SyncHandler.php
@@ -45,7 +45,7 @@ class SyncHandler implements Hookable
     /**
      * @inheritDoc
      */
-    public function sync(string $postType, ?int $postId): void
+    public function sync(string $postType, ?int $postId = null): void
     {
         // allow sync to take longer than current max_execution_time
         set_time_limit(0);


### PR DESCRIPTION
missing parameter when triggering
external content sync from cron