### PR TITLE
fix(jobposting): avoid escaping HTML in jobposting view

### DIFF
--- a/views/v3/single-schema-jobposting.blade.php
+++ b/views/v3/single-schema-jobposting.blade.php
@@ -3,7 +3,7 @@
 @section('article.content')
 
     {{$post->getSchemaProperty('employerOverview') ?? ''}}
-    {{$post->getSchemaProperty('description') ?? ''}}
+    {!!$post->getSchemaProperty('description') ?? ''!!}
 
     @if($post->getSchemaProperty('hiringOrganization')['ethicsPolicy'] ?? null)
         @paper(['padding' => 4])


### PR DESCRIPTION
This pull request includes a small but important change to the `views/v3/single-schema-jobposting.blade.php` file. The change ensures that HTML content within the `description` property is rendered correctly.

* [`views/v3/single-schema-jobposting.blade.php`](diffhunk://#diff-86aab48de9fa895effc75ac150feb690b575f46bd1b6f43e9c6b030c9f8f503bL6-R6): Changed the `description` property rendering from using double curly braces to double exclamation marks to allow HTML content to be rendered.