### PR TITLE
feat: add PostPageEditAction to handle post editing actions

### DIFF
--- a/library/Actions/Admin/PostPageEditAction.php
+++ b/library/Actions/Admin/PostPageEditAction.php
@@ -17,15 +17,32 @@ class PostPageEditAction implements Hookable
 {
     public const ACTION = 'Municipio\post\page\edit';
 
+    /**
+     * Constructor.
+     *
+     * @param AddAction&DoAction $wpService The WordPress service instance.
+     */
     public function __construct(private AddAction&DoAction $wpService)
     {
     }
 
+    /**
+     * @inheritDoc
+     */
     public function addHooks(): void
     {
         $this->wpService->addAction('current_screen', [$this, 'doAction'], 10, 1);
     }
 
+    /**
+     * Fires the action when a post page is edited.
+     *
+     * This method checks if the current screen is a post edit screen and if the post ID is set in the query parameters.
+     * If both conditions are met, it triggers the custom action with the post ID and post type.
+     *
+     * @param WP_Screen $screen The current screen object.
+     * @return void
+     */
     public function doAction(WP_Screen $screen): void
     {
         if ($screen->base !== 'post' || empty($screen->post_type)) {

--- a/library/Actions/Admin/PostPageEditAction.php
+++ b/library/Actions/Admin/PostPageEditAction.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Municipio\Actions\Admin;
+
+use Municipio\HooksRegistrar\Hookable;
+use WP_Screen;
+use WpService\Contracts\AddAction;
+use WpService\Contracts\DoAction;
+
+/**
+ * Class PostPageEditAction
+ * This class is responsible for handling the action when a post page is edited in the admin area.
+ * It hooks into the `current_screen` action and checks if the current screen is a post edit screen.
+ * If so, it triggers a custom action with the post ID and post type.
+ */
+class PostPageEditAction implements Hookable
+{
+    public const ACTION = 'Municipio\post\page\edit';
+
+    public function __construct(private AddAction&DoAction $wpService)
+    {
+    }
+
+    public function addHooks(): void
+    {
+        $this->wpService->addAction('current_screen', [$this, 'doAction'], 10, 1);
+    }
+
+    public function doAction(WP_Screen $screen): void
+    {
+        if ($screen->base !== 'post' || empty($screen->post_type)) {
+            return;
+        }
+
+        if (!isset($_GET['post']) || !is_numeric($_GET['post'])) {
+            return;
+        }
+
+        $this->wpService->doAction(self::ACTION, (int) $_GET['post'], $screen->post_type);
+    }
+}

--- a/library/Actions/Admin/PostPageEditAction.test.php
+++ b/library/Actions/Admin/PostPageEditAction.test.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Municipio\Actions\Admin;
+
+use PHPUnit\Framework\TestCase;
+use WP_Screen;
+use WpService\Implementations\FakeWpService;
+
+class PostPageEditActionTest extends TestCase
+{
+    /**
+     * @testdox class can be instantiated
+     */
+    public function testClassCanBeInstantiated()
+    {
+        $postPageEditAction = new PostPageEditAction(new FakeWpService());
+
+        $this->assertInstanceOf(PostPageEditAction::class, $postPageEditAction);
+    }
+
+    /**
+     * @testdox action runs after the `current_screen` hook
+     */
+    public function testActionRunsAfterCurrentScreenHook()
+    {
+        $wpService          = new FakeWpService(['addAction' => true]);
+        $postPageEditAction = new PostPageEditAction($wpService);
+
+        $postPageEditAction->addHooks();
+
+        $this->assertEquals('current_screen', $wpService->methodCalls['addAction'][0][0]);
+    }
+
+    /**
+     * @testdox action is not run if the screen is not a post
+     */
+    public function testActionIsNotRunIfScreenIsNotPost()
+    {
+        $wpService          = new FakeWpService();
+        $postPageEditAction = new PostPageEditAction($wpService);
+        $wpScreen           = new WP_Screen();
+        $wpScreen->base     = 'not_post';
+
+        $postPageEditAction->doAction($wpScreen);
+
+        $this->assertArrayNotHasKey('doAction', $wpService->methodCalls);
+    }
+
+    /**
+     * @testdox action is not run if the screen is post but no post type is set
+     */
+    public function testActionIsNotRunIfScreenIsPostButNoPostIdSet()
+    {
+        $wpService          = new FakeWpService();
+        $postPageEditAction = new PostPageEditAction($wpService);
+        $wpScreen           = new WP_Screen();
+        $wpScreen->base     = 'post';
+
+        $postPageEditAction->doAction($wpScreen);
+
+        $this->assertArrayNotHasKey('doAction', $wpService->methodCalls);
+    }
+
+    /**
+     * @testdox action is not run if no post id is present in the request
+     */
+    public function testActionIsNotRunIfNoPostIdPresentInRequest()
+    {
+        $wpService           = new FakeWpService();
+        $postPageEditAction  = new PostPageEditAction($wpService);
+        $wpScreen            = new WP_Screen();
+        $wpScreen->base      = 'post';
+        $wpScreen->post_type = 'page';
+
+        $_GET['post'] = null;
+
+        $postPageEditAction->doAction($wpScreen);
+
+        $this->assertArrayNotHasKey('doAction', $wpService->methodCalls);
+    }
+
+    /**
+     * @testdox action is run if the screen is post and post id is set
+     */
+    public function testActionIsRunIfScreenIsPostAndPostIdSet()
+    {
+        $wpService           = new FakeWpService();
+        $postPageEditAction  = new PostPageEditAction($wpService);
+        $wpScreen            = new WP_Screen();
+        $wpScreen->base      = 'post';
+        $wpScreen->post_type = 'page';
+
+        $_GET['post'] = 123;
+
+        $postPageEditAction->doAction($wpScreen);
+
+        $this->assertCount(1, $wpService->methodCalls['doAction']);
+        $this->assertEquals(PostPageEditAction::ACTION, $wpService->methodCalls['doAction'][0][0]);
+        $this->assertEquals(123, $wpService->methodCalls['doAction'][0][1]);
+        $this->assertEquals('page', $wpService->methodCalls['doAction'][0][2]);
+    }
+}

--- a/library/App.php
+++ b/library/App.php
@@ -67,6 +67,11 @@ class App
         private wpdb $wpdb
     ) {
         /**
+         * Run generic custom actions
+         */
+        (new \Municipio\Actions\Admin\PostPageEditAction($this->wpService))->addHooks();
+
+        /**
          * Upgrade
          */
         new \Municipio\Upgrade($this->wpService, $this->acfService);

--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,15 @@ Do action on comment like
 do_action('Municipio/comment/save_like', $comment, $userId, $create);
 ```
 
+### Municipio/post/page/edit
+
+Do action on post edit in admin. Runs after the current_screen hook.
+- ```@param int $postId``` - The post ID
+- ```@param string $postType``` - The post type
+```php
+do_action('Municipio/post/page/edit', $postId, $postType);
+```
+
 ## Filters
 
 ### Municipio/Template/viewData


### PR DESCRIPTION
This pull request introduces a new feature to handle actions when a post page is edited in the admin area. It includes the implementation of the `PostPageEditAction` class, corresponding tests, and updates to the `App` class and documentation.

New feature implementation:

* [`library/Actions/Admin/PostPageEditAction.php`](diffhunk://#diff-a684c4d22f59e0706182e26450ce6de67ced1fcd2ebe851136265da09b733bcaR1-R58): Added the `PostPageEditAction` class to handle the action when a post page is edited in the admin area. This class hooks into the `current_screen` action and triggers a custom action with the post ID and post type.

Testing:

* [`library/Actions/Admin/PostPageEditAction.test.php`](diffhunk://#diff-ab21751643fcb35bf30ecf7a9834835c0e8350082936904d41eb2d340b82b0b2R1-R102): Added unit tests for the `PostPageEditAction` class to ensure it behaves correctly under various conditions, such as whether the screen is a post edit screen and if the post ID is set.

Integration:

* [`library/App.php`](diffhunk://#diff-f866e0aad6c55f4178f285d128ff5bb496ce75bdc2106be7aafbaed7b5cc1e1eR69-R73): Modified the constructor to instantiate the `PostPageEditAction` class and add its hooks, ensuring the custom action is triggered during post page edits.

Documentation:

* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R148-R156): Updated the documentation to include details about the new `Municipio/post/page/edit` action, explaining its parameters and usage.