### PR TITLE
fix: resolve issue with applicators not running in rest response

### DIFF
--- a/library/Customizer/Applicators/ApplicatorCache.php
+++ b/library/Customizer/Applicators/ApplicatorCache.php
@@ -34,8 +34,11 @@ class ApplicatorCache implements Hookable, ApplicatorCacheInterface
    */
     public function addHooks(): void
     {
-        //Create cache on dynamic option generation generation.
+        //Create & apply cache.
         $this->wpService->addAction('kirki_dynamic_css', array($this, 'tryCreateAndApplyCache'), 5);
+
+        //Create & apply cache on rest requests.
+        $this->wpService->addAction('rest_api_init', array($this, 'tryCreateAndApplyCache'), 5);
 
         //Clear cache when customizer is saved (static option cache, and object cache).
         $this->wpService->addAction('customize_save_after', array($this, 'tryClearCache'), 20);
@@ -184,7 +187,7 @@ class ApplicatorCache implements Hookable, ApplicatorCacheInterface
    */
     private function isFrontend(): bool
     {
-        return !is_admin() && !defined('DOING_AJAX') && !defined('REST_REQUEST') && !defined('WP_CLI') && !defined('WP_IMPORTING') && !defined('WP_INSTALLING');
+        return !is_admin() && !defined('WP_CLI') && !defined('WP_IMPORTING') && !defined('WP_INSTALLING');
     }
 
   /**

--- a/library/Customizer/Sections/Menu/Vertical.php
+++ b/library/Customizer/Sections/Menu/Vertical.php
@@ -10,7 +10,7 @@ class Vertical
 
     public function __construct(string $sectionID)
     {
-    
+
         KirkiField::addField([
             'type'        => 'select',
             'settings'    => 'vertical_menu_sublevel_trigger_icon',
@@ -20,7 +20,7 @@ class Vertical
             'default'     => 'expand_more',
             'priority'    => 10,
             'choices'     => [
-                'expand_more' => esc_html__('Directional Caret', 'municipio'), //Standard material icon class
+                'expand_more'                => esc_html__('Directional Caret', 'municipio'), //Standard material icon class
                 'toggleAriaPressedPlusMinus' => esc_html__('Plus/Minus', 'municipio'), //Custom svg
             ],
             'output'      => [
@@ -29,7 +29,7 @@ class Vertical
                     'dataKey' => 'expandIcon',
                     'context' => [
                         [
-                            'context'  => 'component.nav',
+                            'context'  => 'municipio.menu.vertical',
                             'operator' => '==',
                         ]
                     ]
@@ -44,7 +44,7 @@ class Vertical
             'description' => esc_html__('Submenus will indent one step for every level down', 'municipio'),
             'section'     => $sectionID,
             'default'     => false,
-            'choices'   => [
+            'choices'     => [
                 true  => esc_html__('Enabled', 'municipio'),
                 false => esc_html__('Disabled', 'municipio'),
             ],
@@ -55,7 +55,7 @@ class Vertical
                     'dataKey' => 'indentSubLevels',
                     'context' => [
                         [
-                            'context'  => 'component.nav',
+                            'context'  => 'municipio.menu.vertical',
                             'operator' => '==',
                         ]
                     ]

--- a/views/v3/partials/navigation/mobile.blade.php
+++ b/views/v3/partials/navigation/mobile.blade.php
@@ -7,7 +7,7 @@
         'classList' => $classList,
         'depth' => $depth ?? 1,
         'expandLabel' => $lang->expand,
-        'context' => 'site.mobile-menu'
+        'context' => ['site.mobile-menu', 'municipio.menu.vertical']
     ])
     @endnav
 @else

--- a/views/v3/partials/navigation/sidebar.blade.php
+++ b/views/v3/partials/navigation/sidebar.blade.php
@@ -11,7 +11,7 @@
         'direction' => 'vertical',
         'includeToggle' => true,
         'depth' => $depth ?? 1,
-        'context' => ['sidebar', 'municipio.sidebar'],
+        'context' => ['sidebar', 'municipio.sidebar', 'municipio.menu.vertical'],
         'height' => 'sm',
         'expandLabel' => $lang->expand
     ])


### PR DESCRIPTION
This pull request includes several changes to improve caching and navigation context handling in the codebase. The most important changes focus on enhancing the caching mechanism and updating the context for navigation components.

### Improvements to caching mechanism:

* [`library/Customizer/Applicators/ApplicatorCache.php`](diffhunk://#diff-25a54abb299fdef3c48d6300f245b94ded039f63a0c6ee35f25d2d96901eb791L37-R42): Updated the `addHooks` method to create and apply cache on REST requests and simplified the `isFrontend` method by removing unnecessary conditions. [[1]](diffhunk://#diff-25a54abb299fdef3c48d6300f245b94ded039f63a0c6ee35f25d2d96901eb791L37-R42) [[2]](diffhunk://#diff-25a54abb299fdef3c48d6300f245b94ded039f63a0c6ee35f25d2d96901eb791L187-R190)

### Updates to navigation context:

* [`views/v3/partials/navigation/mobile.blade.php`](diffhunk://#diff-d584a9019abf3451fb10536e4996111288fbb4c08cd0fc7ca97f50679b4f7de5L10-R10): Modified the `context` parameter to include 'municipio.menu.vertical' for better context handling in mobile navigation.
* [`views/v3/partials/navigation/sidebar.blade.php`](diffhunk://#diff-b1bb163a95b75a2f2e78c7a97fd6948b10f654fa5516bba0826f27d018798021L14-R14): Updated the `context` parameter to include 'municipio.menu.vertical' for improved context handling in the sidebar navigation.