### PR TITLE
fix: allow menu pages etc. to be saved.

### DIFF
--- a/library/SchemaData/SchemaPropertiesForm/StoreFormFieldValues/StoreFormFieldValues.php
+++ b/library/SchemaData/SchemaPropertiesForm/StoreFormFieldValues/StoreFormFieldValues.php
@@ -40,8 +40,12 @@ class StoreFormFieldValues implements Hookable
      *
      * @param int $postId The ID of the post being saved.
      */
-    public function saveSchemaData(int $postId): void
+    public function saveSchemaData(null|int|string $postId): void
     {
+        if(is_null($postId) || is_string($postId)) {
+            return;
+        }
+
         if (!$this->validNoncePresentInRequest($postId)) {
             return;
         }


### PR DESCRIPTION
Not allowing multiple types for save_post may cause fatal errors. This fix provides neccesary typing for these cases, and instead returns if not a number. 