### PR TITLE
fix: sidestep image downsize alpha png errors

### DIFF
--- a/library/ImageConvert/IntermidiateImageHandler.php
+++ b/library/ImageConvert/IntermidiateImageHandler.php
@@ -80,6 +80,11 @@ class IntermidiateImageHandler implements Hookable
             return false;
         }
 
+        //Set in image processing limits
+        $this->increaseAllowedProcessingTime();
+        $this->increaseAllowedMemoryLimit();
+
+        //Switch to the preferred image editor based on file type
         $this->setPreferedImageEditorByFiletype($image);
 
         $intermediateLocation = $image->getIntermidiateLocation(
@@ -140,6 +145,31 @@ class IntermidiateImageHandler implements Hookable
         ); 
 
         $this->wpService->addFilter('wp_image_editors', fn() => $availableEditors);
+    }
+
+    /**
+     * Increase the allowed processing time for image conversion.
+     * This may avoid timeout errors when processing large images.
+     */
+    private function increaseAllowedProcessingTime(): void
+    {
+        $maxExecutionTime = ini_get('max_execution_time');
+        if ($maxExecutionTime < 300) {
+            ini_set('max_execution_time', '300');
+        }
+    }
+
+    /**
+     * Increase the allowed memory limit for image processing.
+     * This may avoid memory exhaustion errors when processing large images.
+     */
+    private function increaseAllowedMemoryLimit(): void
+    {
+        // Increase the memory limit to handle larger images
+        $memoryLimit = ini_get('memory_limit');
+        if ($memoryLimit < '2048M') {
+            ini_set('memory_limit', '2048M');
+        }
     }
 
     /**

--- a/library/ImageConvert/IntermidiateImageHandler.php
+++ b/library/ImageConvert/IntermidiateImageHandler.php
@@ -159,52 +159,6 @@ class IntermidiateImageHandler implements Hookable
     }
 
     /**
-     * Get the value of a meta key from the metadata of an attachment.
-     *
-     * @param int $attachmentId The attachment ID.
-     * @param string $metaKey The meta key to search for.
-     *
-     * @return mixed The value of the meta key, or false if the key was not found.
-     */
-    private function getAttachmentMetaData($attachmentId, $metaKey): mixed
-    {
-        $metaData = $this->wpService->wpGetAttachmentMetadata($attachmentId);
-        if ($metaData !== false) {
-            if ($result = $this->searchKeyRecursively($metaKey, $metaData)) {
-                return $result;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Search for a key in a multidimensional array recursively.
-     *
-     * @param string $metaKey The key to search for.
-     * @param array $metaData The array to search in.
-     *
-     * @return mixed|null The value of the key if found, otherwise null.
-     */
-    private function searchKeyRecursively($metaKey, $metaData)
-    {
-        if (array_key_exists($metaKey, $metaData)) {
-            return $metaData[$metaKey];
-        }
-
-        foreach ($metaData as $key => $value) {
-            // If the value is an array, search recursively
-            if (is_array($value)) {
-                $result = $this->searchKeyRecursively($metaKey, $value);
-                if ($result !== null) {
-                    return $result;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * Logs an image conversion error with detailed info.
      *
      * @param string $message

--- a/library/ImageConvert/IntermidiateImageHandler.php
+++ b/library/ImageConvert/IntermidiateImageHandler.php
@@ -139,10 +139,10 @@ class IntermidiateImageHandler implements Hookable
         };
 
         $availableEditors = (
-            ($fileTypeMime === 'image/png') ? 
+            ($fileTypeMime === 'image/png') ?
             ['WP_Image_Editor_GD', 'WP_Image_Editor_Imagick'] :
             ['WP_Image_Editor_Imagick', 'WP_Image_Editor_GD']
-        ); 
+        );
 
         $this->wpService->addFilter('wp_image_editors', fn() => $availableEditors);
     }


### PR DESCRIPTION
This change provides a temporary workaround for environments where processing PNG images with alpha transparency causes errors — typically due to issues with the Imagick extension.
	•	Instead of resolving the underlying cause, this PR avoids the issue by prioritizing the GD image editor for PNG files.
	•	This helps prevent fatal errors when Imagick encounters problematic transparency data in PNGs.
	•	Note: This is not a complete fix — it sidesteps the problem by using a more robust fallback editor (GD), which is known to handle these cases more gracefully.

Further investigation is needed to fully resolve compatibility with Imagick and alpha-channel PNGs.