### PR TITLE
feat: toc article

### DIFF
--- a/library/Controller/Singular.php
+++ b/library/Controller/Singular.php
@@ -89,6 +89,13 @@ class Singular extends \Municipio\Controller\BaseController
         //Get age of post
         $this->data['postAgeNotice'] = $this->getPostAgeNotice($this->data['post']);
 
+        // Table of contents
+        $tableOfContentsParser = new \Municipio\Controller\Utils\TableOfContents(
+            $this->data['post']->postContent
+        );
+        $this->data['tableOfContents'] = $tableOfContentsParser->getTableOfContents();
+        $this->data['documentWithAnchors'] = $tableOfContentsParser->getDocumentWithAhchors();
+
         return $this->data;
     }
 

--- a/library/Controller/Utils/TableOfContents.php
+++ b/library/Controller/Utils/TableOfContents.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Municipio\Controller\Utils;
+
+use DOMDocument;
+use DOMXPath;
+use DOMElement;
+
+class TableOfContents
+{
+    private const ANCHOR_PREFIX = 'toc-';
+    private DOMDocument $domObject;
+    private array $headings = [];
+
+    /**
+     * TableOfContents constructor.
+     *
+     * @param string $html The HTML content to parse for headings.
+     */
+    public function __construct(private string $html)
+    {
+      $this->domObject  = self::createDomFromHtml($html);
+      $this->headings   = self::extractHeadingsFromHtml($this->domObject);
+    }
+
+    /**
+     * Returns a table of contents array based on the headings in the provided HTML.
+     *
+     * This method extracts headings (h1–h6) from the HTML and builds a nested
+     * table of contents structure, allowing for easy navigation within the document.
+     *
+     * @return array The structured table of contents.
+     */
+    public function getTableOfContents(): array
+    {
+        return self::buildNestedToc($this->headings) ?? [];
+    }
+
+    /**
+     * Adds anchor IDs to headings in the provided HTML string.
+     *
+     * This method processes the HTML to find headings (h1–h6) and injects
+     * unique IDs based on their text content, allowing for easy linking.
+     *
+     * @return string The modified HTML with anchor IDs added to headings.
+     */
+    public function getDocumentWithAhchors(): string
+    {
+      return self::injectSlugsIntoHtml(
+        $this->html, 
+        $this->headings,
+        $this->domObject
+      );
+    }
+
+    /**
+     * Creates and returns a DOMDocument from the provided HTML string.
+     *
+     * @param string $html
+     * @return DOMDocument
+     */
+    private static function createDomFromHtml(string $html): DOMDocument
+    {
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        @$dom->loadHTML('<?xml encoding="utf-8" ?>' . $html);
+        libxml_clear_errors();
+        return $dom;
+    }
+
+    /**
+     * Extracts headings (h1–h6) from the HTML and returns them as an array.
+     *
+     * @param string $html
+     * @return array
+     */
+    private static function extractHeadingsFromHtml(DOMDocument $dom): array
+    {
+        $xpath    = new DOMXPath($dom);
+        $elements = $xpath->query('//h1 | //h2 | //h3 | //h4 | //h5 | //h6');
+
+        $headings = [];
+        foreach ($elements as $el) {
+            if (!$el instanceof DOMElement) continue;
+
+            $text = trim($el->textContent);
+            $level = (int) substr($el->nodeName, 1);
+            $slug = self::generateSlug($text);
+
+            $headings[] = compact('text', 'level', 'slug');
+        }
+
+        return $headings;
+    }
+
+    /**
+     * Injects slug-based IDs into headings within the HTML.
+     *
+     * @param string $html
+     * @param array $headings
+     * @return string
+     */
+    private static function injectSlugsIntoHtml(string $html, array $headings, DOMDocument $dom): string
+    {
+        if (empty($html) || empty($headings)) return $html;
+
+        $xpath    = new DOMXPath($dom);
+        $elements = $xpath->query('//h1 | //h2 | //h3 | //h4 | //h5 | //h6');
+
+        foreach ($elements as $i => $el) {
+            if (isset($headings[$i]) && $el instanceof DOMElement) {
+                $el->setAttribute('id', $headings[$i]['slug']);
+            }
+        }
+
+        return $dom->saveHTML();
+    }
+
+    /**
+     * Builds a nested table of contents array based on heading levels.
+     *
+     * @param array $headings
+     * @param int $startLevel
+     * @param int $maxDepth
+     * @return array
+     */
+    private static function buildNestedToc(array $headings, int $startLevel = 2, int $maxDepth = 3): array
+    {
+        $items = array_filter($headings, fn($h) => $h['level'] >= $startLevel && $h['level'] < $startLevel + $maxDepth);
+
+        $toc = $stack = [];
+        foreach ($items as $item) {
+            $tocItem = ['label' => $item['text'], 'level' => $item['level'], 'href' => '#' . $item['slug'], 'children' => []];
+            while (!empty($stack) && $tocItem['level'] <= end($stack)['level']) array_pop($stack);
+
+            if (empty($stack)) {
+                $toc[] = $tocItem;
+                $stack[] = &$toc[array_key_last($toc)];
+            } else {
+                $parent = &$stack[array_key_last($stack)];
+                $parent['children'][] = $tocItem;
+                $stack[] = &$parent['children'][array_key_last($parent['children'])];
+            }
+        }
+
+        return $toc;
+    }
+
+    /**
+     * Generates a URL-safe slug from the given text.
+     *
+     * @param string $text
+     * @return string
+     */
+    private static function generateSlug(string $text): string
+    {
+        $slug = strtolower(trim(preg_replace('/[^A-Za-z0-9]+/', '-', $text)));
+        return self::ANCHOR_PREFIX . $slug;
+    }
+}

--- a/views/v3/partials/article.blade.php
+++ b/views/v3/partials/article.blade.php
@@ -79,9 +79,7 @@
     @endif
     
     @section('article.content')
-        @article()
-            {!! $postContentFiltered !!}
-        @endarticle 
+        {!! $documentWithAnchors !!}
     @show
 
     @section('article.content.after')@show

--- a/views/v3/templates/single.blade.php
+++ b/views/v3/templates/single.blade.php
@@ -61,6 +61,26 @@
 @stop
 
 @section('sidebar-right')
+
+@if (!empty($tableOfContents))
+    @paper(['id' => 'table-of-contents', 'padding' => '4', 'class' => 'u-margin__bottom--4'])
+        
+        @typography(['element' => 'h2', 'variant' => 'h2'])
+            {{ __('Table of contents', 'municipio') }}
+        @endtypography
+
+        @listing([
+            'list' => $tableOfContents,
+            'elementType' => 'ul',
+            'class' => 'toc-list',
+            'baseClass' => 'toc-item',
+            'icon' => false,
+        ])
+        @endlisting
+    @endpaper
+@endif
+
+
 @if ($showSidebars)
     @if ($customizer->secondaryNavigationPosition == 'right')
         @if (!empty($secondaryMenu['items']))


### PR DESCRIPTION
This pull request introduces a new feature to generate and display a table of contents (TOC) for articles, improving navigation and accessibility. It includes a utility class for parsing HTML content to extract headings and generate a TOC, updates to render the TOC in the sidebar, and modifications to ensure headings in the article content have unique anchor IDs.

### Table of Contents Feature:

* **TOC Generation Utility**: Added a new `TableOfContents` class in `library/Controller/Utils/TableOfContents.php`. This class extracts headings (h1–h6) from HTML content, generates a nested TOC structure, and injects anchor IDs into headings for easy linking.
* **Integration in Article Controller**: Updated `init()` in `library/Controller/Singular.php` to use the `TableOfContents` class. The TOC and modified HTML with anchors are now included in the controller's data.

### Template Updates:

* **Rendering TOC in Sidebar**: Updated `views/v3/templates/single.blade.php` to display the TOC in the right sidebar if available, using a styled paper component.
* **Anchor-Enhanced Article Content**: Updated `views/v3/partials/article.blade.php` to use the modified HTML with anchor IDs (`$documentWithAnchors`) instead of the original filtered content (`$postContentFiltered`).