### PR TITLE
Fix for the feature "Collapsible search"

### DIFF
--- a/assets/source/3.0/sass/navigation/_collapsible-search.scss
+++ b/assets/source/3.0/sass/navigation/_collapsible-search.scss
@@ -1,129 +1,170 @@
 .site-header {
-    .collapsible-search-form {
-      $parent: &;
-  
-      position: relative;
-  
-      &__form {
-        position: absolute;
+  .collapsible-search-form {
+    $parent: &;
+
+    position: relative;
+
+    &__form {
+      position: absolute;
+      width: 0;
+      top: calc(var(--base, 8px) * -0.5);
+      right: 0;
+      left: auto;
+      transition: all 0.2s ease-in-out;
+      transform-origin: center right;
+      display: flex;
+      padding: calc(var(--base, 8px) * .5);
+      overflow: hidden;
+      z-index: $level-7;
+      opacity: 0;
+
+      @media (max-width: 799px) {
+        position: fixed;
+        top: calc(var(--base, 8px) * 1.5);
+      }
+      
+      &.open {
+        width: calc(100% - calc(var(--base, 8px) * 3.5));
+        opacity: 1;
+
+        @media (min-width: 800px) {
+          width: calc(var(--base, 8px) * 50);
+        }
+
+        @media (max-width: 799px) {
+          width: calc(100% - (var(--base, 8px) * 1.6));
+          right: calc(var(--base, 8px) * 0.8);
+
+          #{$parent}__group {
+            width: 100%;
+          }
+        }
+      }
+      
+      &.closing {
         width: 0;
-        top: calc(var(--base, 8px) * -0.5);
-        right: 0;
-        left: auto;
-        transition: all 0.2s ease-in-out;
-        transform-origin: center right;
-        display: flex;
-        padding: calc(var(--base, 8px) * .5);
-        overflow: hidden;
-        z-index: $level-7;
-        opacity: 0;
-        
-        &.open {
-          width: calc(var(--base, 8px) * 35);
-          opacity: 1;
-  
-          @media (min-width: 800px) {
-            width: calc(var(--base, 8px) * 50);
-          }
-        }
-        
-        &.closing {
-          width: 0;
-        }
       }
-  
-      &__group {
-        position: relative;
+    }
+
+    &__group {
+      position: relative;
+      flex: 1;
+      
+      .c-field {
         flex: 1;
-        
-        .c-field {
-          flex: 1;
-          min-width: 0;
-  
-          @media (min-width: 800px) {
-            min-width: calc(var(--base, 8px) * 44);
-          }
-  
-          .c-field_focus-styler {
-            border-radius: calc(var(--base, 8px) * 6);
-            outline-width: 3px;
-          }
-  
-          input {
-            padding-right: calc(var(--base, 8px) * 5);
-            border-radius: calc(var(--base, 8px) * 6);
-  
-            &:focus {
-              outline-style: none;
-            }
-          }
-  
-          &__inner {
-            border-radius: calc(var(--base, 8px) * 6);
-            background-color: $color-white;
+        min-width: 0;
+
+        @media (min-width: 800px) {
+          min-width: calc(var(--base, 8px) * 44);
+        }
+
+        .c-field_focus-styler {
+          outline-color: var(--c-button-primary-color);
+          border-radius: calc(var(--base, 8px) * 6);
+          outline-width: 3px;
+        }
+
+        input {
+          font-size: 16px;
+          padding-right: calc(var(--base, 8px) * 5);
+          border-radius: calc(var(--base, 8px) * 6);
+
+          &:focus {
+            outline-style: none;
           }
         }
+
+        &__inner {
+          background-color: $color-white;
+          border-radius: calc(var(--base, 8px) * 6);
+          background-color: $color-white;
+          border: 2px solid var(--c-button-primary-color);
+        }
       }
-  
-      &__submit-icon {
-        appearance: none;
+    }
+
+    &__submit-icon {
+      appearance: none;
+      background: transparent;
+      border: 0;
+      padding: 0;
+      position: absolute;
+      inset: 50% 5px auto auto;
+      transform: translateY(-50%);
+      border-radius: 50%;
+      outline-width: 3px;
+      cursor: pointer;
+      height: calc(100% - 10px);
+      width: calc(var(--base, 8px)* 5);
+
+      &:disabled {
         background: transparent;
-        border: 0;
-        padding: 0;
+      }
+
+      .c-icon {
+        color: var(--c-button-primary-color);
+      }
+    }
+
+    &__close-button {
+      appearance: none;
+      background: transparent;
+      border: none;
+      background-color: $color-secondary-light;
+      outline-width: 3px;
+      border-top-right-radius: calc(var(--base, 8px) * 6);
+      border-bottom-right-radius: calc(var(--base, 8px) * 6);
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      color: $color-black;
+      position: relative;
+      cursor: pointer;
+      z-index: -1;
+
+      &::before {
+        content: "";
+
+        width: calc(var(--base, 8px) * 4);
+        height: 100%;
+        display: block;
         position: absolute;
-        inset: 50% 1px auto auto;
-        transform: translateY(-50%);
-        border-radius: 50%;
-        outline-width: 3px;
-        cursor: pointer;
-        height: calc(100% - 2px);
-      }
-  
-      &__close-button {
-        appearance: none;
-        background: transparent;
-        border: none;
-        padding: 0 calc(var(--base, 8px) * 1.5) 0 calc(var(--base, 8px) * 1);
         background-color: $color-secondary-light;
-        outline-width: 3px;
-        border-top-right-radius: calc(var(--base, 8px) * 6);
-        border-bottom-right-radius: calc(var(--base, 8px) * 6);
-        position: relative;
-        cursor: pointer;
+        inset: 0 100% 0 auto;
         z-index: -1;
-  
-        &::before {
-          content: "";
-  
-          width: calc(var(--base, 8px) * 4);
-          height: 100%;
-          display: block;
-          position: absolute;
-          background-color: $color-secondary-light;
-          inset: 0 100% 0 auto;
-          z-index: -1;
-        }
-      }
-    }
-  
-    .c-header__upper-left {
-      .collapsible-search-form {
-        &__form {
-          transform-origin: center left;
-          right: auto;
-          left: 0;
-        }
-      }
-    }
-  
-    .c-header__upper-center {
-      .collapsible-search-form {
-        &__form {
-          transform-origin: center center;
-          right: auto;
-          left: 50%;
-          transform: translateX(-50%);
-        }
       }
     }
   }
+
+  .c-header__upper-left {
+    .collapsible-search-form {
+      &__form {
+        transform-origin: center left;
+        right: auto;
+        left: 0;
+      }
+    }
+  }
+
+  .c-header__upper-center {
+    .collapsible-search-form {
+      &__form {
+        transform-origin: center center;
+        right: auto;
+        left: 50%;
+        transform: translateX(-50%);
+      }
+    }
+  }
+}
+
+.admin-bar {
+  .collapsible-search-form {
+    position: relative;
+  
+    &__form {
+      @media (max-width: 799px) {
+        top: calc(var(--wp-admin--admin-bar--height, 32px) + 10px);
+      }
+    }
+  }
+}

--- a/assets/source/3.0/sass/navigation/_collapsible-search.scss
+++ b/assets/source/3.0/sass/navigation/_collapsible-search.scss
@@ -24,15 +24,18 @@
       }
       
       &.open {
-        width: calc(100% - calc(var(--base, 8px) * 3.5));
+        width: calc(100% - (var(--base, 8px) * 1.6));
         opacity: 1;
 
         @media (min-width: 800px) {
+          width: calc(var(--base, 8px) * 40);
+        }
+
+        @media (min-width: 1000px) {
           width: calc(var(--base, 8px) * 50);
         }
 
         @media (max-width: 799px) {
-          width: calc(100% - (var(--base, 8px) * 1.6));
           right: calc(var(--base, 8px) * 0.8);
 
           #{$parent}__group {
@@ -55,6 +58,10 @@
         min-width: 0;
 
         @media (min-width: 800px) {
+          min-width: calc(var(--base, 8px) * 30);
+        }
+
+        @media (min-width: 1000px) {
           min-width: calc(var(--base, 8px) * 44);
         }
 


### PR DESCRIPTION
Restore missing styles for Collapsible Search
This pull request reintroduces critical styling that was unintentionally removed in previous changes:

The original implementation of the Collapsible Search feature was merged without some of the necessary styles for proper layout and appearance.

On February 4, additional styling—particularly important for the mobile view—was removed in a commit by @NiclasNorin, which further affected the visual integrity of the component.

What this fixes
The following visual bugs have been resolved:

Broken mobile layout:
<img width="336" height="74" alt="broken-collapsible-search-mobile" src="https://github.com/user-attachments/assets/7d49e7ea-dc25-4699-9c17-f67e4418e995" />

Broken desktop layout:
<img width="416" height="72" alt="broken-collapsible-search" src="https://github.com/user-attachments/assets/0612cae2-7cc9-4711-a6a4-9a7c5aa419c9" />

✅ Fixed layout (after this PR):
<img width="414" height="78" alt="fixed-collapsible-search" src="https://github.com/user-attachments/assets/87abd952-f2e9-4393-98c6-39f16e8a0ad7" />

> ⚠️ Note: Please disregard the colors in the screenshots — they reflect my local development environment and may differ from the default theme.

This PR aims to restore the intended appearance of the collapsible search component across breakpoints and prevent future visual regressions.