### PR TITLE
fix: check that a conversion hasent run, or are older than 24 hours o…

### DIFF
--- a/library/ImageConvert/Config/ImageConvertConfig.php
+++ b/library/ImageConvert/Config/ImageConvertConfig.php
@@ -233,6 +233,23 @@ class ImageConvertConfig implements ImageConvertConfigInterface
     }
 
     /**
+     * If a reduced mode should be used for image runtime conversion.
+     * This will reduce the number of conversions triggered by looking at last
+     * update time of the post.
+     */
+    public function useReducedModeForImageConversionRuntimeStrategy(): bool
+    {
+        $reducedMode = (defined('MUNICIPIO_IMAGE_CONVERT_USE_REDUCED_MODE') && constant('MUNICIPIO_IMAGE_CONVERT_USE_REDUCED_MODE') === true)
+            ? true
+            : false;
+            
+        return $this->wpService->applyFilters(
+            $this->createFilterKey(__FUNCTION__),
+            $reducedMode
+        );
+    }
+
+    /**
      * Get the selected image conversion strategy.
      */
     public function getImageConversionStrategy(): ?string

--- a/library/ImageConvert/Config/ImageConvertConfigInterface.php
+++ b/library/ImageConvert/Config/ImageConvertConfigInterface.php
@@ -20,4 +20,5 @@ interface ImageConvertConfigInterface
     public function pageCacheExpiry(): int;
     public function getImageConversionStrategy(): ?string;
     public function getDefaultImageConversionLogWriter(): ?string;
+    public function useReducedModeForImageConversionRuntimeStrategy(): bool;
 }

--- a/library/ImageConvert/README.md
+++ b/library/ImageConvert/README.md
@@ -35,6 +35,13 @@ define('MUNICIPIO_IMAGE_CONVERT_STRATEGY', 'runtime');
 **Available strategies:**
 - `runtime` (default) - Process images immediately during page load
 
+### MUNICIPIO_IMAGE_CONVERT_USE_REDUCED_MODE
+Check if the page has been updated lately before running the image conversion strategy for logged out users. 
+
+```php
+define('MUNICIPIO_IMAGE_CONVERT_USE_REDUCED_MODE', true); 
+````
+
 #### MUNICIPIO_IMAGE_CONVERT_DEFAULT_LOG_WRITER
 Configures the default log writer for debugging and monitoring.
 

--- a/library/ImageConvert/Strategy/StrategyFactory.php
+++ b/library/ImageConvert/Strategy/StrategyFactory.php
@@ -62,7 +62,9 @@ class StrategyFactory
 
         return match ($strategy) {
             ConversionStrategy::RUNTIME => new RuntimeConversionStrategy(
-                $imageProcessor
+                $imageProcessor,
+                $this->wpService,
+                $this->config
             )
         };
     }


### PR DESCRIPTION
This pull request updates the `RuntimeConversionStrategy` class to add logic for controlling when image conversion is triggered, preventing redundant conversions within a 24-hour period or if the post hasn't been updated. The strategy now checks post meta data to determine if conversion should run, and records the last conversion time.

Enhancements to image conversion control:

* Added a private constant `META_KEY_LAST_CONVERSION` to store the meta key used for tracking the last conversion timestamp.
* Implemented the `shouldRunImageConvert()` method to determine if image conversion should proceed, based on the last conversion time and the last post update time.
* Implemented the `hasRanImageConvert()` method to update the post meta with the current timestamp after conversion runs.
* Updated the `process()` method to use the new logic: it only processes the image if conversion is needed, and records when conversion occurs.…