### PR TITLE
fix(ExternalContent): normalize image properties

### DIFF
--- a/library/SchemaData/ExternalContent/SyncHandler/FilterBeforeSync/ConvertImagePropsToImageObjects.php
+++ b/library/SchemaData/ExternalContent/SyncHandler/FilterBeforeSync/ConvertImagePropsToImageObjects.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Municipio\SchemaData\ExternalContent\SyncHandler\FilterBeforeSync;
+
+use Municipio\SchemaData\ExternalContent\SyncHandler\SyncHandler;
+use Municipio\HooksRegistrar\Hookable;
+use Municipio\Schema\BaseType;
+use Municipio\Schema\Schema;
+use Municipio\SchemaData\Utils\GetSchemaPropertiesWithParamTypes;
+use WpService\Contracts\AddFilter;
+
+/**
+ * Class ConvertImagePropsToImageObjects
+ * Ensures that all properties, root or nested, that accept ImageObject or ImageObject[] as type are converted to ImageObject instances.
+ * This is particularly useful when dealing with external data sources that may provide image data as simple URLs or strings.
+ */
+class ConvertImagePropsToImageObjects implements Hookable
+{
+    /**
+     * Cache for schema properties per type.
+     * @var array<string, array>
+     */
+    private array $schemaPropertiesCache = [];
+
+    /**
+     * Constructor.
+     *
+     * @param AddFilter $wpService
+     * @param GetSchemaPropertiesWithParamTypes|null $getSchemaPropertiesWithParamTypes
+     */
+    public function __construct(
+        private AddFilter $wpService,
+        private GetSchemaPropertiesWithParamTypes $getSchemaPropertiesWithParamTypes = new GetSchemaPropertiesWithParamTypes()
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addHooks(): void
+    {
+        $this->wpService->addFilter(SyncHandler::FILTER_BEFORE, [$this, 'convert']);
+    }
+
+    /**
+     * Convert image properties to ImageObject instances.
+     *
+     * @param BaseType[] $schemaObjects
+     * @return BaseType[]
+     */
+    public function convert(array $schemaObjects): array
+    {
+        return array_map(fn(BaseType $schemaObject) => $this->convertImageProperties($schemaObject), $schemaObjects);
+    }
+
+    /**
+     * Recursively convert image properties to ImageObject instances.
+     *
+     * @param BaseType $schemaObject
+     * @return BaseType
+     */
+    private function convertImageProperties(BaseType $schemaObject): BaseType
+    {
+        $schemaType = get_class($schemaObject);
+
+        // Use cached schema properties if available
+        if (!isset($this->schemaPropertiesCache[$schemaType])) {
+            $this->schemaPropertiesCache[$schemaType] = $this->getSchemaPropertiesWithParamTypes->getSchemaPropertiesWithParamTypes($schemaType);
+        }
+        $schemaProperties = $this->schemaPropertiesCache[$schemaType];
+
+        foreach ($schemaProperties as $propertyName => $paramTypes) {
+            $propertyValue = $schemaObject->getProperty($propertyName);
+
+            if ($this->isImageProperty($paramTypes)) {
+                $converted = $this->convertToImageObject($propertyValue);
+                // Only set property if changed
+                if ($converted !== $propertyValue) {
+                    $schemaObject->setProperty($propertyName, $converted);
+                }
+                continue;
+            }
+
+            if ($propertyValue instanceof BaseType) {
+                $converted = $this->convertImageProperties($propertyValue);
+                if ($converted !== $propertyValue) {
+                    $schemaObject->setProperty($propertyName, $converted);
+                }
+            }
+        }
+
+        return $schemaObject;
+    }
+
+    /**
+     * Check if property types include ImageObject or ImageObject[].
+     *
+     * @param array $paramTypes
+     * @return bool
+     */
+    private function isImageProperty(array $paramTypes): bool
+    {
+        return in_array('ImageObject', $paramTypes, true) || in_array('ImageObject[]', $paramTypes, true);
+    }
+
+    /**
+     * Convert value to ImageObject instance(s) if needed.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    private function convertToImageObject(mixed $value): mixed
+    {
+        if (is_string($value) && filter_var($value, FILTER_VALIDATE_URL)) {
+            return Schema::imageObject()->url($value);
+        }
+
+        if (is_array($value) && !empty($value)) {
+            return array_map(fn($item) => $this->convertToImageObject($item), $value);
+        }
+
+        return $value;
+    }
+}

--- a/library/SchemaData/ExternalContent/SyncHandler/FilterBeforeSync/ConvertImagePropsToImageObjectsTest.php
+++ b/library/SchemaData/ExternalContent/SyncHandler/FilterBeforeSync/ConvertImagePropsToImageObjectsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Municipio\SchemaData\ExternalContent\SyncHandler\FilterBeforeSync;
+
+use Municipio\Schema\ImageObject;
+use Municipio\Schema\Schema;
+use PHPUnit\Framework\TestCase;
+use WpService\Contracts\AddFilter;
+
+class ConvertImagePropsToImageObjectsTest extends TestCase
+{
+    /**
+     * @testdox converts image properties to ImageObject instances
+     */
+    public function testConvertsImagePropertiesToImageObjectInstances(): void
+    {
+        $schemaObjects = [Schema::thing()->image('https://example.com/image.jpg')];
+        $filter        = $this->getInstance();
+        $result        = $filter->convert($schemaObjects);
+        $this->assertInstanceOf(ImageObject::class, $result[0]->getProperty('image'));
+        $this->assertEquals('https://example.com/image.jpg', $result[0]->getProperty('image')->getProperty('url'));
+    }
+
+    /**
+     * @testdox converts array of image URLs to array of ImageObject instances
+     */
+    public function testConvertsArrayOfImageUrlsToArrayOfImageObjectInstances(): void
+    {
+        $schemaObjects = [Schema::thing()->image(['https://example.com/image1.jpg', 'https://example.com/image2.jpg'])];
+        $filter        = $this->getInstance();
+        $result        = $filter->convert($schemaObjects);
+
+        $this->assertInstanceOf(ImageObject::class, $result[0]->getProperty('image')[0]);
+        $this->assertInstanceOf(ImageObject::class, $result[0]->getProperty('image')[1]);
+        $this->assertEquals('https://example.com/image1.jpg', $result[0]->getProperty('image')[0]->getProperty('url'));
+        $this->assertEquals('https://example.com/image2.jpg', $result[0]->getProperty('image')[1]->getProperty('url'));
+    }
+
+    /**
+     * @testdox converts nested image properties to ImageObject instances
+     */
+    public function testConvertsNestedImagePropertiesToImageObjectInstances(): void
+    {
+        $schemaObjects = [
+            Schema::event()->actor(
+                Schema::person()->image('https://example.com/nested-image.jpg')
+            )
+        ];
+        $filter        = $this->getInstance();
+        $result        = $filter->convert($schemaObjects);
+        $this->assertInstanceOf(ImageObject::class, $result[0]->getProperty('actor')->getProperty('image'));
+        $this->assertEquals('https://example.com/nested-image.jpg', $result[0]->getProperty('actor')->getProperty('image')->getProperty('url'));
+    }
+
+    /**
+     * @testdox converts nested array of image URLs to array of ImageObject instances
+     */
+    public function testConvertsNestedArrayOfImageUrlsToArrayOfImageObjectInstances(): void
+    {
+        $schemaObjects = [
+            Schema::event()->actor(
+                Schema::person()->image(['https://example.com/nested-image1.jpg', 'https://example.com/nested-image2.jpg'])
+            )
+        ];
+        $filter        = $this->getInstance();
+        $result        = $filter->convert($schemaObjects);
+
+        $this->assertInstanceOf(ImageObject::class, $result[0]->getProperty('actor')->getProperty('image')[0]);
+        $this->assertInstanceOf(ImageObject::class, $result[0]->getProperty('actor')->getProperty('image')[1]);
+        $this->assertEquals('https://example.com/nested-image1.jpg', $result[0]->getProperty('actor')->getProperty('image')[0]->getProperty('url'));
+        $this->assertEquals('https://example.com/nested-image2.jpg', $result[0]->getProperty('actor')->getProperty('image')[1]->getProperty('url'));
+    }
+
+    /**
+     * @testdox does not modify if image string is not a url
+     */
+    public function testDoesNotModifyIfImageStringIsNotAUrl(): void
+    {
+        $schemaObjects = [Schema::thing()->image('Not a URL')];
+        $filter        = $this->getInstance();
+        $result        = $filter->convert($schemaObjects);
+        $this->assertIsString($result[0]->getProperty('image'));
+        $this->assertEquals('Not a URL', $result[0]->getProperty('image'));
+    }
+
+    private function getInstance(): ConvertImagePropsToImageObjects
+    {
+        $wpService = new class implements AddFilter {
+            public function addFilter(string $hookName, callable $callback, int $priority = 10, int $acceptedArgs = 1): true
+            {
+                return true;
+            }
+        };
+
+        return new ConvertImagePropsToImageObjects($wpService);
+    }
+}

--- a/library/SchemaData/ExternalContent/SyncHandler/SyncHandler.php
+++ b/library/SchemaData/ExternalContent/SyncHandler/SyncHandler.php
@@ -168,6 +168,7 @@ class SyncHandler implements Hookable, SyncHandlerInterface
     private function applyFiltersBeforeSync(): void
     {
         (new \Municipio\SchemaData\ExternalContent\SyncHandler\FilterBeforeSync\FilterOutDuplicateObjectById())->addHooks();
+        (new \Municipio\SchemaData\ExternalContent\SyncHandler\FilterBeforeSync\ConvertImagePropsToImageObjects($this->wpService))->addHooks();
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a new filter for the external content sync process to automatically convert image property values to `ImageObject` instances, ensuring consistent schema handling of image data from external sources. Comprehensive unit tests are included to verify correct behavior for root, nested, and array image properties, as well as edge cases.

### New image property conversion filter

* Added `ConvertImagePropsToImageObjects` filter (`library/SchemaData/ExternalContent/SyncHandler/FilterBeforeSync/ConvertImagePropsToImageObjects.php`) that recursively converts any property (root or nested) accepting `ImageObject` or `ImageObject[]` types to proper `ImageObject` instances, handling both single URLs and arrays of URLs.
* Registered the new filter in the sync handler so it runs before syncing external content (`SyncHandler::applyFiltersBeforeSync`).

### Testing and validation

* Added a comprehensive test suite (`ConvertImagePropsToImageObjectsTest.php`) covering conversion of single image URLs, arrays of image URLs, nested image properties, and ensuring non-URL strings are not converted.