### PR TITLE
fix: Handle multiple locations for schools and preschools

### DIFF
--- a/library/Controller/School/AddressGeneratorTest.php
+++ b/library/Controller/School/AddressGeneratorTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Municipio\Controller\School;
 
+use Municipio\Schema\Place;
+use Municipio\Schema\Schema;
 use PHPUnit\Framework\TestCase;
 use WpService\Contracts\_x;
 use WpService\Implementations\FakeWpService;
@@ -19,24 +21,29 @@ class AddressGeneratorTest extends TestCase
 
     public function testGenerateReturnsNullAddressAndDirectionsIfAddressIsEmpty(): void
     {
-        $preschool = \Municipio\Schema\Schema::preschool()->address('');
+        $preschool = \Municipio\Schema\Schema::preschool()->location([
+            Schema::place(), // No address
+            Schema::place()->address(''), // Empty address
+        ]);
         $generator = new AddressGenerator($preschool, $this->getWpService());
         $result    = $generator->generate();
-        $this->assertNull($result['address']);
-        $this->assertNull($result['directionsLink']);
+        $this->assertNull($result);
+        $this->assertNull($result);
     }
 
     public function testGenerateReturnsValidAddressAndDirections(): void
     {
         $address   = 'Testgatan 1, 12345 Teststad';
-        $preschool = \Municipio\Schema\Schema::preschool()->address($address);
+        $preschool = \Municipio\Schema\Schema::preschool()->location([
+            Schema::place()->address($address)
+        ]);
         $generator = new AddressGenerator($preschool, $this->getWpService());
         $result    = $generator->generate();
-        $this->assertSame($address, $result['address']);
+        $this->assertSame($address, $result[0]['address']);
         $this->assertEquals([
             'label' => 'Get directions',
             'href'  => 'https://www.google.com/maps/dir//' . urlencode($address)
-        ], $result['directionsLink']);
+        ], $result[0]['directionsLink']);
     }
 
     private function getWpService(): _x

--- a/library/Controller/School/MapComponentAttributesGenerator.php
+++ b/library/Controller/School/MapComponentAttributesGenerator.php
@@ -3,6 +3,7 @@
 namespace Municipio\Controller\School;
 
 use Municipio\Schema\ElementarySchool;
+use Municipio\Schema\Place;
 use Municipio\Schema\Preschool;
 
 class MapComponentAttributesGenerator
@@ -13,16 +14,58 @@ class MapComponentAttributesGenerator
 
     public function generate(): mixed
     {
-        $latitude  = $this->school->getProperty('latitude');
-        $longitude = $this->school->getProperty('longitude');
+        $places = $this->ensureArrayOfPlaces($this->school->getProperty('location'));
+
+        if (empty($places)) {
+            return null;
+        }
+
+        return [
+            'pins'          => array_map(fn($place) => $this->mapPlaceToPin($place), $places),
+            'startPosition' => [ 'lat' => $this->getStartLatitude($places), 'lng' => $this->getStartLongitude($places), 'zoom' => 14 ],
+        ];
+    }
+
+    private function mapPlaceToPin(Place $place): ?array
+    {
+        $latitude  = $place->getProperty('latitude');
+        $longitude = $place->getProperty('longitude');
 
         if (empty($latitude) || empty($longitude)) {
             return null;
         }
 
         return [
-            'pins'          => [ [ 'lat' => $latitude, 'lng' => $longitude ] ],
-            'startPosition' => [ 'lat' => $latitude, 'lng' => $longitude, 'zoom' => 14 ],
+            'lat'     => $latitude,
+            'lng'     => $longitude,
+            'tooltip' => [
+                'title' => $place->getProperty('address')
+            ]
         ];
+    }
+
+    private function ensureArrayOfPlaces(mixed $location): array
+    {
+        if (!is_array($location)) {
+            $location = [ $location ];
+        }
+
+        return array_filter($location, fn($item) => is_a($item, Place::class) && $item->getProperty('latitude') !== null && $item->getProperty('longitude') !== null);
+    }
+
+
+    /**
+     * Get the starting latitude by finding the center point between all places
+     */
+    private function getStartLatitude(array $places): ?float
+    {
+        $latitudes = array_map(fn($place) => $place->getProperty('latitude'), $places);
+        return array_sum($latitudes) / count($latitudes);
+    }
+
+    private function getStartLongitude(array $places): ?float
+    {
+        $longitudes = array_map(fn($place) => $place->getProperty('longitude'), $places);
+        return array_sum($longitudes) / count($longitudes);
     }
 }

--- a/library/Controller/School/MapComponentAttributesGeneratorTest.php
+++ b/library/Controller/School/MapComponentAttributesGeneratorTest.php
@@ -4,36 +4,69 @@ declare(strict_types=1);
 
 namespace Municipio\Controller\School;
 
+use Municipio\Schema\Schema;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 class MapComponentAttributesGeneratorTest extends TestCase
 {
     public function testCanBeInstantiated(): void
     {
-        $preschool = \Municipio\Schema\Schema::preschool();
+        $preschool = Schema::preschool();
         $generator = new MapComponentAttributesGenerator($preschool);
         $this->assertInstanceOf(MapComponentAttributesGenerator::class, $generator);
     }
 
+    #[TestDox('Generate method returns null if no valid coordinates are provided')]
     public function testGenerateReturnsNullIfLatitudeOrLongitudeMissing(): void
     {
-        $preschool = \Municipio\Schema\Schema::preschool()->latitude(null)->longitude(59.33);
-        $generator = new MapComponentAttributesGenerator($preschool);
-        $this->assertNull($generator->generate());
+        $preschool = Schema::preschool()->location([
+            Schema::place(), // Missing both latitude and longitude
+            Schema::place()->latitude(18.06), // Missing longitude
+            Schema::place()->longitude(59.33), // Missing latitude
+        ]);
 
-        $preschool = \Municipio\Schema\Schema::preschool()->latitude(18.06)->longitude(null);
         $generator = new MapComponentAttributesGenerator($preschool);
+
         $this->assertNull($generator->generate());
     }
 
-    public function testGenerateReturnsValidPinsAndStartPosition(): void
+    #[TestDox('Generate method returns valid pins when latitude and longitude are provided')]
+    public function testGenerateReturnsValidPins(): void
     {
-        $preschool = \Municipio\Schema\Schema::preschool()->latitude(59.33)->longitude(18.06);
+        $preschool = Schema::preschool()->location([
+            Schema::place()->latitude(59.33)->longitude(18.06)->address('Testgatan 1, 12345 Teststad'),
+            Schema::place()->latitude(60.00)->longitude(19.00)->address('Testgatan 2, 12345 Teststad'), // This one should be ignored
+        ]);
         $generator = new MapComponentAttributesGenerator($preschool);
         $result    = $generator->generate();
-        $this->assertEquals([
-            'pins'          => [ [ 'lat' => 59.33, 'lng' => 18.06 ] ],
-            'startPosition' => [ 'lat' => 59.33, 'lng' => 18.06, 'zoom' => 14 ],
-        ], $result);
+
+        $expectedPins = [
+            [
+                'lat'     => 59.33,
+                'lng'     => 18.06,
+                'tooltip' => ['title' => 'Testgatan 1, 12345 Teststad'],
+            ],
+            [
+                'lat'     => 60.00,
+                'lng'     => 19.00,
+                'tooltip' => ['title' => 'Testgatan 2, 12345 Teststad'],
+            ],
+        ];
+        $this->assertEquals($expectedPins, $result['pins']);
+    }
+
+    #[TestDox('Generate method returns start position when valid coordinates are provided')]
+    public function testGenerateReturnsStartPosition(): void
+    {
+        $preschool = Schema::preschool()->location([
+            Schema::place()->latitude(59.33)->longitude(18.06),
+            Schema::place()->latitude(60.00)->longitude(19.00),
+        ]);
+        $generator = new MapComponentAttributesGenerator($preschool);
+        $result    = $generator->generate();
+
+        $this->assertIsFloat($result['startPosition']['lat']);
+        $this->assertIsFloat($result['startPosition']['lng']);
     }
 }

--- a/library/Controller/SingularElementarySchool.php
+++ b/library/Controller/SingularElementarySchool.php
@@ -23,7 +23,7 @@ class SingularElementarySchool extends \Municipio\Controller\Singular
             'accordionListItems'         => new School\ElementarySchool\AccordionListItemsGenerator($schema, $this->wpService),
             'sliderItems'                => new School\SliderItemsGenerator($schema),
             'personsAttributes'          => new School\PersonComponentsAttributesGenerator($schema),
-            'address'                    => new School\AddressGenerator($schema, $this->wpService),
+            'addresses'                  => new School\AddressGenerator($schema, $this->wpService),
             'mapAttributes'              => new School\MapComponentAttributesGenerator($schema),
             'usps'                       => new School\ElementarySchool\UspsGenerator($schema, $this->post->getId(), $this->wpService),
             'actions'                    => new School\ActionsGenerator($schema),

--- a/library/Controller/SingularPreschool.php
+++ b/library/Controller/SingularPreschool.php
@@ -24,7 +24,7 @@ class SingularPreschool extends \Municipio\Controller\Singular
             'accordionListItems'         => new School\Preschool\AccordionListItemsGenerator($schema, $this->wpService),
             'sliderItems'                => new School\SliderItemsGenerator($schema),
             'personsAttributes'          => new School\PersonComponentsAttributesGenerator($schema),
-            'address'                    => new School\AddressGenerator($schema, $this->wpService),
+            'addresses'                  => new School\AddressGenerator($schema, $this->wpService),
             'mapAttributes'              => new School\MapComponentAttributesGenerator($schema),
             'usps'                       => new School\Preschool\UspsGenerator($schema, $this->post->getId(), $this->wpService),
             'actions'                    => new School\ActionsGenerator($schema),

--- a/views/v3/single-schema-elementary-school.blade.php
+++ b/views/v3/single-schema-elementary-school.blade.php
@@ -133,22 +133,25 @@
             @endelement
         @endif
 
-        @if(!empty($address))
+@if(!empty($addresses))
             @paper(['classList' => ['u-padding--2']])
                 @element()
                     @typography(['element' => 'h2'])
                         {!! $lang->addressLabel !!}
                     @endtypography
-                    @if(!empty($address['address']))
-                        @typography()
-                            {!! $address['address'] !!}
-                        @endtypography
-                    @endif
-                    @if(!empty($address['directionsLink']))
-                        @link(['href' => $address['directionsLink']['href']])
-                            {!! $address['directionsLink']['label'] !!}
-                        @endlink
-                    @endif
+                    @foreach ($addresses as $address)
+                        @if(!empty($address['address']))
+                            @typography()
+                                {!! $address['address'] !!}
+                            @endtypography
+                        @endif
+                        @if(!empty($address['directionsLink']))
+                            @link(['href' => $address['directionsLink']['href']])
+                                {!! $address['directionsLink']['label'] !!}
+                            @endlink
+                        @endif
+                    @endforeach
+                    
                     @openStreetMap([
                         ...$mapAttributes,
                         'height' => '400px',

--- a/views/v3/single-schema-preschool.blade.php
+++ b/views/v3/single-schema-preschool.blade.php
@@ -146,22 +146,25 @@
             @endelement
         @endif
 
-        @if(!empty($address))
+        @if(!empty($addresses))
             @paper(['classList' => ['u-padding--2']])
                 @element()
                     @typography(['element' => 'h2'])
                         {!! $lang->addressLabel !!}
                     @endtypography
-                    @if(!empty($address['address']))
-                        @typography()
-                            {!! $address['address'] !!}
-                        @endtypography
-                    @endif
-                    @if(!empty($address['directionsLink']))
-                        @link(['href' => $address['directionsLink']['href']])
-                            {!! $address['directionsLink']['label'] !!}
-                        @endlink
-                    @endif
+                    @foreach ($addresses as $address)
+                        @if(!empty($address['address']))
+                            @typography()
+                                {!! $address['address'] !!}
+                            @endtypography
+                        @endif
+                        @if(!empty($address['directionsLink']))
+                            @link(['href' => $address['directionsLink']['href']])
+                                {!! $address['directionsLink']['label'] !!}
+                            @endlink
+                        @endif
+                    @endforeach
+                    
                     @openStreetMap([
                         ...$mapAttributes,
                         'height' => '400px',


### PR DESCRIPTION
When a school or preschool has multiple locations, we should display all addresses