### PR TITLE
fix: handle datePosted DateTime correctly in JobPostingDecoratorTest

### DIFF
--- a/library/SchemaData/ExternalContent/WpPostArgsFromSchemaObject/JobPostingDecorator.php
+++ b/library/SchemaData/ExternalContent/WpPostArgsFromSchemaObject/JobPostingDecorator.php
@@ -47,7 +47,11 @@ class JobPostingDecorator implements WpPostArgsFromSchemaObjectInterface
         }
 
         if (!empty($schemaObject['datePosted'])) {
-            $post['post_date'] = $schemaObject['datePosted'];
+            $datePosted = $schemaObject['datePosted'];
+            if ($datePosted instanceof \DateTimeInterface) {
+                $datePosted = $datePosted->format('Y-m-d H:i:s');
+            }
+            $post['post_date'] = $datePosted;
         }
 
         return $post;

--- a/library/SchemaData/ExternalContent/WpPostArgsFromSchemaObject/JobPostingDecoratorTest.php
+++ b/library/SchemaData/ExternalContent/WpPostArgsFromSchemaObject/JobPostingDecoratorTest.php
@@ -5,6 +5,7 @@ namespace Municipio\SchemaData\ExternalContent\WpPostArgsFromSchemaObject;
 use Municipio\SchemaData\ExternalContent\Sources\Source;
 use PHPUnit\Framework\TestCase;
 use Municipio\Schema\JobPosting;
+use PHPUnit\Framework\Attributes\TestDox;
 
 class JobPostingDecoratorTest extends TestCase
 {
@@ -18,5 +19,29 @@ class JobPostingDecoratorTest extends TestCase
         $post = $factory->transform($schemaObject);
 
         $this->assertEquals('Job title', $post['post_title']);
+    }
+
+    #[TestDox('Sets post_date from schemaObject[\'datePosted\'] if is JobPosting')]
+    public function testSetsPostDateFromDatePosted()
+    {
+        $factory      = new JobPostingDecorator(new WpPostArgsFromSchemaObject());
+        $schemaObject = new JobPosting();
+
+        $schemaObject->datePosted(new \DateTime('2023-01-01 12:00:00'));
+        $post = $factory->transform($schemaObject);
+
+        $this->assertEquals('2023-01-01 12:00:00', $post['post_date']);
+    }
+
+    #[TestDox('Handles case when datePosted is a DateTimeInterface')]
+    public function testHandlesDatePostedAsDateTimeInterface()
+    {
+        $factory      = new JobPostingDecorator(new WpPostArgsFromSchemaObject());
+        $schemaObject = new JobPosting();
+
+        $schemaObject->datePosted(new \DateTime('2023-01-01 12:00:00'));
+        $post = $factory->transform($schemaObject);
+
+        $this->assertEquals('2023-01-01 12:00:00', $post['post_date']);
     }
 }


### PR DESCRIPTION
fixes issue when trying to create new wp post with datePosted as DateTime object