### PR TITLE
added ignore rule for lint

### DIFF
--- a/Modularity/source/php/Options/General.php
+++ b/Modularity/source/php/Options/General.php
@@ -53,7 +53,8 @@ class General extends \Modularity\Options
         add_meta_box(
             'modularity-mb-core-options',
             __('Core options', 'modularity'),
-            static function () {
+            // @mago-ignore lint:prefer-static-closure
+            function () {
                 $templatePath = \Modularity\Helper\Wp::getTemplate('core-options', 'options/partials');
                 include $templatePath;
             },


### PR DESCRIPTION
Some included files are using the $this pointer even though it is not declared in the calling function. Avoid making these functions static.