### PR TITLE
feat: add Site Editor color support via theme.json

### DIFF
--- a/library/App.php
+++ b/library/App.php
@@ -263,6 +263,13 @@ class App
         new \Municipio\Customizer($this->wpService, $this->wpdb);
 
         /**
+         * Theme.json integration - bridges Site Editor colors with existing CSS variables
+         */
+        new \Municipio\ThemeJson\ThemeJsonGenerator($this->wpService);
+        new \Municipio\ThemeJson\CssVariableBridge($this->wpService);
+        new \Municipio\ThemeJson\BlockTemplateHybridSupport($this->wpService);
+
+        /**
          * Block customizations
          */
         new \Municipio\Blocks\Columns();

--- a/library/ThemeJson/BlockTemplateHybridSupport.php
+++ b/library/ThemeJson/BlockTemplateHybridSupport.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Municipio\ThemeJson;
+
+use WpService\WpService;
+
+/**
+ * Enables block theme features (like Global Styles) while keeping PHP template rendering.
+ *
+ * This class allows the theme to be recognized as a block theme by WordPress,
+ * enabling the Site Editor's Global Styles panel, while still using the existing
+ * PHP/Blade template system for actual page rendering.
+ */
+class BlockTemplateHybridSupport
+{
+    public function __construct(private WpService $wpService)
+    {
+        // Prevent block templates from being used for rendering - keep using PHP templates
+        $this->wpService->addFilter('template_include', [$this, 'usePhpTemplates'], 99);
+
+        // Indicate that this theme supports block templates (enables Site Editor features)
+        $this->wpService->addAction('after_setup_theme', [$this, 'addBlockThemeSupport'], 5);
+    }
+
+    /**
+     * Ensure PHP templates are used instead of block templates.
+     *
+     * When WordPress finds a matching block template, it would normally use it.
+     * This filter intercepts that and returns the original PHP template path.
+     *
+     * @param string $template The template path WordPress wants to use
+     * @return string The PHP template path to use instead
+     */
+    public function usePhpTemplates(string $template): string
+    {
+        // If WordPress resolved to a block template (.html), redirect to PHP template
+        if (str_ends_with($template, '.html')) {
+            // Let WordPress find the appropriate PHP template
+            $phpTemplate = $this->findPhpTemplate();
+            if ($phpTemplate) {
+                return $phpTemplate;
+            }
+        }
+
+        return $template;
+    }
+
+    /**
+     * Find the appropriate PHP template based on WordPress template hierarchy.
+     *
+     * @return string|null PHP template path or null if not found
+     */
+    private function findPhpTemplate(): ?string
+    {
+        // Get the template from the standard WordPress hierarchy
+        // This checks for index.php in the theme
+        $templates = ['index.php'];
+
+        foreach ($templates as $templateFile) {
+            $path = get_template_directory() . '/' . $templateFile;
+            if (file_exists($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Add theme support for block templates.
+     *
+     * This tells WordPress that the theme supports block templates,
+     * which enables the Site Editor's Global Styles panel.
+     */
+    public function addBlockThemeSupport(): void
+    {
+        // Enable block template parts - allows Global Styles editing
+        $this->wpService->addThemeSupport('block-template-parts');
+    }
+}

--- a/library/ThemeJson/ColorDerivation.php
+++ b/library/ThemeJson/ColorDerivation.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Municipio\ThemeJson;
+
+use Municipio\Helper\Color;
+
+class ColorDerivation
+{
+    /**
+     * Derive dark, light, and contrasting color variants from a base color.
+     *
+     * @param string $baseColor Hex color value (e.g., '#ae0b05')
+     * @return array{dark: string, light: string, contrasting: string}
+     */
+    public static function deriveVariants(string $baseColor): array
+    {
+        return [
+            'dark'        => self::darken($baseColor, 15),
+            'light'       => self::lighten($baseColor, 15),
+            'contrasting' => Color::getBestContrastColor($baseColor, true),
+        ];
+    }
+
+    /**
+     * Darken a hex color by a percentage.
+     *
+     * @param string $hex Hex color value
+     * @param int $percent Percentage to darken (0-100)
+     * @return string Darkened hex color
+     */
+    public static function darken(string $hex, int $percent): string
+    {
+        return self::adjustBrightness($hex, -$percent);
+    }
+
+    /**
+     * Lighten a hex color by a percentage.
+     *
+     * @param string $hex Hex color value
+     * @param int $percent Percentage to lighten (0-100)
+     * @return string Lightened hex color
+     */
+    public static function lighten(string $hex, int $percent): string
+    {
+        return self::adjustBrightness($hex, $percent);
+    }
+
+    /**
+     * Adjust brightness of a hex color.
+     *
+     * @param string $hex Hex color value
+     * @param int $percent Positive to lighten, negative to darken
+     * @return string Adjusted hex color
+     */
+    private static function adjustBrightness(string $hex, int $percent): string
+    {
+        $hex = ltrim($hex, '#');
+
+        if (strlen($hex) === 3) {
+            $hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+        }
+
+        $r = hexdec(substr($hex, 0, 2));
+        $g = hexdec(substr($hex, 2, 2));
+        $b = hexdec(substr($hex, 4, 2));
+
+        $factor = $percent / 100;
+
+        if ($factor > 0) {
+            // Lighten: move toward 255
+            $r = $r + ((255 - $r) * $factor);
+            $g = $g + ((255 - $g) * $factor);
+            $b = $b + ((255 - $b) * $factor);
+        } else {
+            // Darken: move toward 0
+            $factor = abs($factor);
+            $r = $r * (1 - $factor);
+            $g = $g * (1 - $factor);
+            $b = $b * (1 - $factor);
+        }
+
+        $r = max(0, min(255, round($r)));
+        $g = max(0, min(255, round($g)));
+        $b = max(0, min(255, round($b)));
+
+        return sprintf('#%02x%02x%02x', $r, $g, $b);
+    }
+
+    /**
+     * Check if a string is a valid hex color.
+     *
+     * @param string $color Color string to validate
+     * @return bool True if valid hex color
+     */
+    public static function isValidHexColor(string $color): bool
+    {
+        return (bool) preg_match('/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $color);
+    }
+
+    /**
+     * Normalize a color value (handle rgba, rgb, or hex).
+     * Returns hex if possible, original value otherwise.
+     *
+     * @param string $color Color value to normalize
+     * @return string|null Hex color or null if not convertible
+     */
+    public static function normalizeToHex(string $color): ?string
+    {
+        $color = trim($color);
+
+        // Already hex
+        if (self::isValidHexColor($color)) {
+            return strpos($color, '#') === 0 ? $color : '#' . $color;
+        }
+
+        // Handle rgb/rgba
+        if (preg_match('/^rgba?\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/', $color, $matches)) {
+            return sprintf('#%02x%02x%02x', (int) $matches[1], (int) $matches[2], (int) $matches[3]);
+        }
+
+        return null;
+    }
+}

--- a/library/ThemeJson/ColorDerivationTest.php
+++ b/library/ThemeJson/ColorDerivationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Municipio\ThemeJson;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+class ColorDerivationTest extends TestCase
+{
+    #[TestDox('darken reduces brightness of a color')]
+    public function testDarkenReducesBrightness(): void
+    {
+        $result = ColorDerivation::darken('#ffffff', 50);
+        $this->assertEquals('#808080', $result);
+    }
+
+    #[TestDox('lighten increases brightness of a color')]
+    public function testLightenIncreasesBrightness(): void
+    {
+        $result = ColorDerivation::lighten('#000000', 50);
+        $this->assertEquals('#808080', $result);
+    }
+
+    #[TestDox('isValidHexColor returns true for valid hex colors')]
+    public function testIsValidHexColorReturnsTrueForValidColors(): void
+    {
+        $this->assertTrue(ColorDerivation::isValidHexColor('#ae0b05'));
+        $this->assertTrue(ColorDerivation::isValidHexColor('ae0b05'));
+        $this->assertTrue(ColorDerivation::isValidHexColor('#fff'));
+        $this->assertTrue(ColorDerivation::isValidHexColor('fff'));
+    }
+
+    #[TestDox('isValidHexColor returns false for invalid colors')]
+    public function testIsValidHexColorReturnsFalseForInvalidColors(): void
+    {
+        $this->assertFalse(ColorDerivation::isValidHexColor('rgb(0,0,0)'));
+        $this->assertFalse(ColorDerivation::isValidHexColor('rgba(0,0,0,0.5)'));
+        $this->assertFalse(ColorDerivation::isValidHexColor('invalid'));
+        $this->assertFalse(ColorDerivation::isValidHexColor('#gggggg'));
+    }
+
+    #[TestDox('normalizeToHex returns hex from hex input')]
+    public function testNormalizeToHexReturnsHexFromHexInput(): void
+    {
+        $this->assertEquals('#ae0b05', ColorDerivation::normalizeToHex('#ae0b05'));
+        $this->assertEquals('#ae0b05', ColorDerivation::normalizeToHex('ae0b05'));
+        $this->assertEquals('#fff', ColorDerivation::normalizeToHex('fff'));
+    }
+
+    #[TestDox('normalizeToHex converts rgb to hex')]
+    public function testNormalizeToHexConvertsRgbToHex(): void
+    {
+        $this->assertEquals('#ff0000', ColorDerivation::normalizeToHex('rgb(255, 0, 0)'));
+        $this->assertEquals('#000000', ColorDerivation::normalizeToHex('rgb(0,0,0)'));
+    }
+
+    #[TestDox('normalizeToHex converts rgba to hex')]
+    public function testNormalizeToHexConvertsRgbaToHex(): void
+    {
+        $this->assertEquals('#ff0000', ColorDerivation::normalizeToHex('rgba(255, 0, 0, 0.5)'));
+    }
+
+    #[TestDox('normalizeToHex returns null for invalid input')]
+    public function testNormalizeToHexReturnsNullForInvalidInput(): void
+    {
+        $this->assertNull(ColorDerivation::normalizeToHex('invalid'));
+        $this->assertNull(ColorDerivation::normalizeToHex('hsl(0, 100%, 50%)'));
+    }
+
+    #[TestDox('deriveVariants returns dark, light, and contrasting colors')]
+    public function testDeriveVariantsReturnsAllVariants(): void
+    {
+        $variants = ColorDerivation::deriveVariants('#ae0b05');
+
+        $this->assertArrayHasKey('dark', $variants);
+        $this->assertArrayHasKey('light', $variants);
+        $this->assertArrayHasKey('contrasting', $variants);
+
+        // Dark should be darker than original
+        $this->assertNotEquals('#ae0b05', $variants['dark']);
+        // Light should be lighter than original
+        $this->assertNotEquals('#ae0b05', $variants['light']);
+        // Contrasting should be either very light or very dark
+        $this->assertNotEmpty($variants['contrasting']);
+    }
+}

--- a/library/ThemeJson/CssVariableBridge.php
+++ b/library/ThemeJson/CssVariableBridge.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Municipio\ThemeJson;
+
+use WpService\WpService;
+
+class CssVariableBridge
+{
+    /**
+     * Mapping from existing CSS variable names to theme.json preset slugs.
+     * This bridges --color-* variables to --wp--preset--color--* variables.
+     */
+    private array $variableMapping = [
+        // Primary colors
+        '--color-primary'             => 'primary',
+        '--color-primary-dark'        => 'primary-dark',
+        '--color-primary-light'       => 'primary-light',
+        '--color-primary-contrasting' => 'primary-contrasting',
+
+        // Secondary colors
+        '--color-secondary'             => 'secondary',
+        '--color-secondary-dark'        => 'secondary-dark',
+        '--color-secondary-light'       => 'secondary-light',
+        '--color-secondary-contrasting' => 'secondary-contrasting',
+
+        // Background & text
+        '--color-background' => 'background',
+        '--color-base'       => 'foreground',
+
+        // State colors
+        '--color-success'             => 'success',
+        '--color-success-contrasting' => 'success-contrasting',
+        '--color-warning'             => 'warning',
+        '--color-warning-contrasting' => 'warning-contrasting',
+        '--color-danger'              => 'danger',
+        '--color-danger-contrasting'  => 'danger-contrasting',
+        '--color-info'                => 'info',
+        '--color-info-contrasting'    => 'info-contrasting',
+    ];
+
+    /**
+     * Default values for CSS variables (fallbacks if theme.json not loaded).
+     * These match the defaults in Customizer/Sections/Colors.php.
+     */
+    private array $defaultValues = [
+        '--color-primary'             => '#ae0b05',
+        '--color-primary-dark'        => '#770000',
+        '--color-primary-light'       => '#e84c31',
+        '--color-primary-contrasting' => '#ffffff',
+        '--color-secondary'             => '#ec6701',
+        '--color-secondary-dark'        => '#b23700',
+        '--color-secondary-light'       => '#ff983e',
+        '--color-secondary-contrasting' => '#ffffff',
+        '--color-background'            => '#f5f5f5',
+        '--color-base'                  => '#000000',
+        '--color-success'               => '#91d736',
+        '--color-success-contrasting'   => '#000000',
+        '--color-warning'               => '#efbb21',
+        '--color-warning-contrasting'   => '#000000',
+        '--color-danger'                => '#d73740',
+        '--color-danger-contrasting'    => '#ffffff',
+        '--color-info'                  => '#3d3d3d',
+        '--color-info-contrasting'      => '#ffffff',
+    ];
+
+    public function __construct(private WpService $wpService)
+    {
+        // Output bridge CSS early to ensure it's available before component styles
+        $this->wpService->addAction('wp_head', [$this, 'outputCssVariableBridge'], 5);
+        $this->wpService->addAction('admin_head', [$this, 'outputCssVariableBridge'], 5);
+    }
+
+    /**
+     * Output CSS that bridges WordPress preset variables to existing CSS variable names.
+     * This maintains backwards compatibility with existing component styles.
+     */
+    public function outputCssVariableBridge(): void
+    {
+        $css = $this->generateBridgeCss();
+
+        if (empty($css)) {
+            return;
+        }
+
+        echo '<style id="theme-json-css-bridge">' . "\n";
+        echo $css;
+        echo '</style>' . "\n";
+    }
+
+    /**
+     * Generate the bridge CSS content.
+     *
+     * @return string CSS content
+     */
+    private function generateBridgeCss(): string
+    {
+        $rules = [];
+
+        foreach ($this->variableMapping as $existingVar => $presetSlug) {
+            $fallback = $this->defaultValues[$existingVar] ?? 'inherit';
+            $rules[] = sprintf(
+                '    %s: var(--wp--preset--color--%s, %s);',
+                $existingVar,
+                $presetSlug,
+                $fallback
+            );
+        }
+
+        if (empty($rules)) {
+            return '';
+        }
+
+        return ":root {\n" . implode("\n", $rules) . "\n}\n";
+    }
+}

--- a/library/ThemeJson/CssVariableBridgeTest.php
+++ b/library/ThemeJson/CssVariableBridgeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Municipio\ThemeJson;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use WpService\Implementations\FakeWpService;
+
+class CssVariableBridgeTest extends TestCase
+{
+    #[TestDox('constructor registers wp_head and admin_head actions')]
+    public function testConstructorRegistersActions(): void
+    {
+        $wpService = new FakeWpService(['addAction' => true]);
+
+        new CssVariableBridge($wpService);
+
+        $this->assertCount(2, $wpService->methodCalls['addAction'] ?? []);
+        $this->assertEquals('wp_head', $wpService->methodCalls['addAction'][0][0]);
+        $this->assertEquals('admin_head', $wpService->methodCalls['addAction'][1][0]);
+    }
+
+    #[TestDox('outputCssVariableBridge outputs CSS with variable mappings')]
+    public function testOutputCssVariableBridgeOutputsCss(): void
+    {
+        $wpService = new FakeWpService(['addAction' => true]);
+        $bridge    = new CssVariableBridge($wpService);
+
+        ob_start();
+        $bridge->outputCssVariableBridge();
+        $output = ob_get_clean();
+
+        // Check that output contains the style tag
+        $this->assertStringContainsString('<style id="theme-json-css-bridge">', $output);
+        $this->assertStringContainsString('</style>', $output);
+
+        // Check that it contains CSS variable mappings
+        $this->assertStringContainsString('--color-primary:', $output);
+        $this->assertStringContainsString('var(--wp--preset--color--primary', $output);
+
+        // Check that it includes fallback values
+        $this->assertStringContainsString('#ae0b05', $output); // Primary default
+    }
+
+    #[TestDox('outputCssVariableBridge includes all required color mappings')]
+    public function testOutputCssVariableBridgeIncludesAllMappings(): void
+    {
+        $wpService = new FakeWpService(['addAction' => true]);
+        $bridge    = new CssVariableBridge($wpService);
+
+        ob_start();
+        $bridge->outputCssVariableBridge();
+        $output = ob_get_clean();
+
+        // Primary colors
+        $this->assertStringContainsString('--color-primary:', $output);
+        $this->assertStringContainsString('--color-primary-dark:', $output);
+        $this->assertStringContainsString('--color-primary-light:', $output);
+        $this->assertStringContainsString('--color-primary-contrasting:', $output);
+
+        // Secondary colors
+        $this->assertStringContainsString('--color-secondary:', $output);
+
+        // Background and text
+        $this->assertStringContainsString('--color-background:', $output);
+        $this->assertStringContainsString('--color-base:', $output);
+
+        // State colors
+        $this->assertStringContainsString('--color-success:', $output);
+        $this->assertStringContainsString('--color-warning:', $output);
+        $this->assertStringContainsString('--color-danger:', $output);
+        $this->assertStringContainsString('--color-info:', $output);
+    }
+}

--- a/library/ThemeJson/ThemeJsonGenerator.php
+++ b/library/ThemeJson/ThemeJsonGenerator.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Municipio\ThemeJson;
+
+use WpService\WpService;
+
+class ThemeJsonGenerator
+{
+    /**
+     * Mapping from Customizer theme_mod names to theme.json palette entries.
+     * Only includes colors that should appear in Site Editor.
+     */
+    private array $colorMapping = [
+        'color_palette_primary' => [
+            'base' => ['slug' => 'primary', 'name' => 'Primary'],
+            'dark' => ['slug' => 'primary-dark', 'name' => 'Primary Dark'],
+            'light' => ['slug' => 'primary-light', 'name' => 'Primary Light'],
+            'contrasting' => ['slug' => 'primary-contrasting', 'name' => 'Primary Contrasting'],
+        ],
+        'color_palette_secondary' => [
+            'base' => ['slug' => 'secondary', 'name' => 'Secondary'],
+            'dark' => ['slug' => 'secondary-dark', 'name' => 'Secondary Dark'],
+            'light' => ['slug' => 'secondary-light', 'name' => 'Secondary Light'],
+            'contrasting' => ['slug' => 'secondary-contrasting', 'name' => 'Secondary Contrasting'],
+        ],
+        'color_background' => [
+            'background' => ['slug' => 'background', 'name' => 'Background'],
+        ],
+        'color_text' => [
+            'base' => ['slug' => 'foreground', 'name' => 'Foreground'],
+        ],
+        'color_palette_state_success' => [
+            'base' => ['slug' => 'success', 'name' => 'Success'],
+            'contrasting' => ['slug' => 'success-contrasting', 'name' => 'Success Contrasting'],
+        ],
+        'color_palette_state_warning' => [
+            'base' => ['slug' => 'warning', 'name' => 'Warning'],
+            'contrasting' => ['slug' => 'warning-contrasting', 'name' => 'Warning Contrasting'],
+        ],
+        'color_palette_state_danger' => [
+            'base' => ['slug' => 'danger', 'name' => 'Danger'],
+            'contrasting' => ['slug' => 'danger-contrasting', 'name' => 'Danger Contrasting'],
+        ],
+        'color_palette_state_info' => [
+            'base' => ['slug' => 'info', 'name' => 'Info'],
+            'contrasting' => ['slug' => 'info-contrasting', 'name' => 'Info Contrasting'],
+        ],
+    ];
+
+    public function __construct(private WpService $wpService)
+    {
+        $this->wpService->addFilter('wp_theme_json_data_theme', [$this, 'mergeCustomizerColors'], 10, 1);
+    }
+
+    /**
+     * Merge Customizer color values into theme.json palette.
+     *
+     * @param \WP_Theme_JSON_Data $themeJson The theme.json data object
+     * @return \WP_Theme_JSON_Data Modified theme.json data
+     */
+    public function mergeCustomizerColors(\WP_Theme_JSON_Data $themeJson): \WP_Theme_JSON_Data
+    {
+        $palette = $this->buildPaletteFromThemeMods();
+
+        if (empty($palette)) {
+            return $themeJson;
+        }
+
+        $newData = [
+            'version' => 3,
+            'settings' => [
+                'color' => [
+                    'palette' => $palette,
+                ],
+            ],
+        ];
+
+        return $themeJson->update_with($newData);
+    }
+
+    /**
+     * Build the color palette array from theme_mod values.
+     *
+     * @return array Array of palette entries for theme.json
+     */
+    private function buildPaletteFromThemeMods(): array
+    {
+        $palette = [];
+
+        foreach ($this->colorMapping as $themeMod => $choices) {
+            $value = $this->wpService->getThemeMod($themeMod);
+
+            if (!is_array($value)) {
+                continue;
+            }
+
+            foreach ($choices as $choice => $meta) {
+                if (!empty($value[$choice])) {
+                    $color = $this->normalizeColor($value[$choice]);
+                    if ($color !== null) {
+                        $palette[] = [
+                            'slug'  => $meta['slug'],
+                            'color' => $color,
+                            'name'  => $meta['name'],
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $palette;
+    }
+
+    /**
+     * Normalize color value to a format theme.json can use.
+     * Handles hex, rgb, and rgba formats.
+     *
+     * @param string $color The color value to normalize
+     * @return string|null The normalized color or null if invalid
+     */
+    private function normalizeColor(string $color): ?string
+    {
+        $color = trim($color);
+
+        // Already a valid hex color
+        if (preg_match('/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $color)) {
+            return strpos($color, '#') === 0 ? $color : '#' . $color;
+        }
+
+        // Handle rgb/rgba - theme.json supports these directly
+        if (preg_match('/^rgba?\s*\(/', $color)) {
+            return $color;
+        }
+
+        return null;
+    }
+}

--- a/library/ThemeJson/ThemeJsonGeneratorTest.php
+++ b/library/ThemeJson/ThemeJsonGeneratorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Municipio\ThemeJson;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use WpService\Implementations\FakeWpService;
+
+class ThemeJsonGeneratorTest extends TestCase
+{
+    #[TestDox('constructor registers the wp_theme_json_data_theme filter')]
+    public function testConstructorRegistersFilter(): void
+    {
+        $wpService = new FakeWpService(['addFilter' => true]);
+
+        new ThemeJsonGenerator($wpService);
+
+        $this->assertCount(1, $wpService->methodCalls['addFilter'] ?? []);
+        $this->assertEquals('wp_theme_json_data_theme', $wpService->methodCalls['addFilter'][0][0]);
+    }
+
+    #[TestDox('mergeCustomizerColors returns original theme json when no customizer values exist')]
+    public function testMergeCustomizerColorsReturnsOriginalWhenNoValues(): void
+    {
+        $wpService = new FakeWpService([
+            'addFilter'   => true,
+            'getThemeMod' => false, // No theme mods set
+        ]);
+
+        $generator = new ThemeJsonGenerator($wpService);
+
+        // Create a mock WP_Theme_JSON_Data
+        $themeJsonData = $this->createMock(\WP_Theme_JSON_Data::class);
+        $themeJsonData->expects($this->never())->method('update_with');
+
+        $result = $generator->mergeCustomizerColors($themeJsonData);
+
+        $this->assertSame($themeJsonData, $result);
+    }
+}

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,0 +1,7 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"backgroundColor":"foreground","textColor":"background","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+    <!-- wp:paragraph {"align":"center"} -->
+    <p class="has-text-align-center">Site Editor Preview - Actual site uses PHP templates</p>
+    <!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,0 +1,5 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"backgroundColor":"primary","textColor":"primary-contrasting","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-primary-contrasting-color has-primary-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+    <!-- wp:site-title {"level":0} /-->
+</div>
+<!-- /wp:group -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,9 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} -->
+<main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+    <!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,141 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 3,
+    "settings": {
+        "appearanceTools": true,
+        "useRootPaddingAwareAlignments": true,
+        "color": {
+            "background": true,
+            "custom": true,
+            "customDuotone": false,
+            "customGradient": true,
+            "defaultDuotone": false,
+            "defaultGradients": false,
+            "defaultPalette": false,
+            "link": true,
+            "text": true,
+            "palette": [
+                {
+                    "slug": "primary",
+                    "color": "#ae0b05",
+                    "name": "Primary"
+                },
+                {
+                    "slug": "primary-dark",
+                    "color": "#770000",
+                    "name": "Primary Dark"
+                },
+                {
+                    "slug": "primary-light",
+                    "color": "#e84c31",
+                    "name": "Primary Light"
+                },
+                {
+                    "slug": "primary-contrasting",
+                    "color": "#ffffff",
+                    "name": "Primary Contrasting"
+                },
+                {
+                    "slug": "secondary",
+                    "color": "#ec6701",
+                    "name": "Secondary"
+                },
+                {
+                    "slug": "secondary-dark",
+                    "color": "#b23700",
+                    "name": "Secondary Dark"
+                },
+                {
+                    "slug": "secondary-light",
+                    "color": "#ff983e",
+                    "name": "Secondary Light"
+                },
+                {
+                    "slug": "secondary-contrasting",
+                    "color": "#ffffff",
+                    "name": "Secondary Contrasting"
+                },
+                {
+                    "slug": "background",
+                    "color": "#f5f5f5",
+                    "name": "Background"
+                },
+                {
+                    "slug": "foreground",
+                    "color": "#000000",
+                    "name": "Foreground"
+                },
+                {
+                    "slug": "success",
+                    "color": "#91d736",
+                    "name": "Success"
+                },
+                {
+                    "slug": "success-contrasting",
+                    "color": "#000000",
+                    "name": "Success Contrasting"
+                },
+                {
+                    "slug": "warning",
+                    "color": "#efbb21",
+                    "name": "Warning"
+                },
+                {
+                    "slug": "warning-contrasting",
+                    "color": "#000000",
+                    "name": "Warning Contrasting"
+                },
+                {
+                    "slug": "danger",
+                    "color": "#d73740",
+                    "name": "Danger"
+                },
+                {
+                    "slug": "danger-contrasting",
+                    "color": "#ffffff",
+                    "name": "Danger Contrasting"
+                },
+                {
+                    "slug": "info",
+                    "color": "#3d3d3d",
+                    "name": "Info"
+                },
+                {
+                    "slug": "info-contrasting",
+                    "color": "#ffffff",
+                    "name": "Info Contrasting"
+                }
+            ]
+        },
+        "spacing": {
+            "units": ["px", "em", "rem", "%", "vw", "vh"],
+            "spacingSizes": [
+                { "slug": "30", "size": "1rem", "name": "Small" },
+                { "slug": "40", "size": "1.5rem", "name": "Medium" },
+                { "slug": "50", "size": "2rem", "name": "Large" },
+                { "slug": "60", "size": "3rem", "name": "Extra Large" }
+            ]
+        },
+        "typography": {
+            "customFontSize": true
+        }
+    },
+    "styles": {
+        "color": {
+            "background": "var(--wp--preset--color--background)",
+            "text": "var(--wp--preset--color--foreground)"
+        },
+        "elements": {
+            "link": {
+                "color": {
+                    "text": "var(--wp--preset--color--primary-dark)"
+                },
+                ":hover": {
+                    "color": {
+                        "text": "var(--wp--preset--color--primary)"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR enables theme colors to be edited through the WordPress Site Editor (Appearance > Design > Styles > Colors) as the first phase of migrating from a classic theme to a block theme.

  - Add theme.json with 18-color palette (primary, secondary, state colors, etc.)
  - Add ThemeJsonGenerator to dynamically merge Customizer color values into theme.json
  - Add CssVariableBridge to maintain backwards compatibility with existing --color-* CSS variables
  - Add minimal block templates (templates/, parts/) to enable Site Editor Global Styles
  - Add BlockTemplateHybridSupport to ensure PHP/Blade templates still render the frontend

  How it works

  1. Site Editor uses the block templates for preview and enables Global Styles color editing
  2. Frontend still renders using existing PHP/Blade templates (no change to current behavior)
  3. Colors changed in Site Editor are saved and applied via CSS variables
  4. Backwards compatible - existing Customizer colors work, existing --color-* variables work

  Test plan

  - Navigate to Appearance > Design > Styles > Colors
  - Verify theme color palette is visible (Primary, Secondary, Success, etc.)
  - Change a color and verify preview updates
  - Save and verify frontend reflects the change
  - Verify existing Customizer color changes still work
  - Run vendor/bin/phpunit library/ThemeJson/ - all 14 tests pass