### PR TITLE
Require `symfony/polyfill-mbstring` version `^1.0` instead of old `1.17.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 	"require": {
 		"php": "^8.2",
 		"composer/installers": "^2.3",
-		"symfony/polyfill-mbstring": "1.17.0",
+		"symfony/polyfill-mbstring": "^1.0",
 		"helsingborg-stad/acf-export-manager": ">=1.0.0",
 		"pragmarx/ia-arr": "^7.3",
 		"symfony/polyfill-php80": "^1.27",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b05dd03ae3d48bc8b610a72da45c251",
+    "content-hash": "a7e4864409d28ac57ff9ff1fb33ead03",
     "packages": [
         {
             "name": "astrotomic/php-deepface",
@@ -2913,28 +2913,33 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.17.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fa79b11539418b02fc5e1897267673ba2c19419c"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fa79b11539418b02fc5e1897267673ba2c19419c",
-                "reference": "fa79b11539418b02fc5e1897267673ba2c19419c",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.17-dev"
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2969,7 +2974,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.17.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -2981,11 +2986,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/polyfill-php80",


### PR DESCRIPTION
Having `symfony/polyfill-mbstring` locked to such an old version is preventing us from installing other dependencies which depend on a later version of the package. Since `1.17.0` was released [back in 2020](https://github.com/symfony/polyfill-mbstring/tags?after=v1.20.0) (!) I think it's safe to say that this upgrade is overdue.