### PR TITLE
feat: add endpoints for saving and retreiving customizations

### DIFF
--- a/library/Api/Customize/Config/CustomizeConfig.php
+++ b/library/Api/Customize/Config/CustomizeConfig.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Config;
+
+use WpService\Contracts\ApplyFilters;
+
+class CustomizeConfig implements CustomizeConfigInterface
+{
+    public function __construct(
+        private ApplyFilters $wpService,
+        private string $filterPrefix = 'Municipio/Api/Customize',
+        private string $themeModKey = 'tokens',
+        private string $getPermissionCapability = 'edit_theme_options',
+        private string $savePermissionCapability = 'edit_theme_options',
+    ) {}
+
+    /**
+     * Theme mod key used to persist design token customization JSON.
+     */
+    public function getThemeModKey(): string
+    {
+        $key = $this->wpService->applyFilters(
+            $this->createFilterKey(__FUNCTION__),
+            $this->themeModKey,
+        );
+
+        return is_string($key) && !empty($key) ? $key : $this->themeModKey;
+    }
+
+    /**
+     * Capability required to access the GET customize endpoint.
+     */
+    public function getGetPermissionCapability(): string
+    {
+        $capability = $this->wpService->applyFilters(
+            $this->createFilterKey(__FUNCTION__),
+            $this->getPermissionCapability,
+        );
+
+        return is_string($capability) && !empty($capability) ? $capability : $this->getPermissionCapability;
+    }
+
+    /**
+     * Capability required to access the SAVE customize endpoint.
+     */
+    public function getSavePermissionCapability(): string
+    {
+        $capability = $this->wpService->applyFilters(
+            $this->createFilterKey(__FUNCTION__),
+            $this->savePermissionCapability,
+        );
+
+        return is_string($capability) && !empty($capability) ? $capability : $this->savePermissionCapability;
+    }
+
+    private function createFilterKey(string $filter = ''): string
+    {
+        return $this->filterPrefix . '/' . $filter;
+    }
+}

--- a/library/Api/Customize/Config/CustomizeConfig.php
+++ b/library/Api/Customize/Config/CustomizeConfig.php
@@ -55,8 +55,15 @@ class CustomizeConfig implements CustomizeConfigInterface
         return is_string($capability) && !empty($capability) ? $capability : $this->savePermissionCapability;
     }
 
+    /**
+     * Creates a filter key by combining the prefix and the provided suffix.
+     *
+     * @param string $filter Optional suffix for the filter key.
+     *
+     * @return string The combined filter key.
+     */
     private function createFilterKey(string $filter = ''): string
     {
-        return $this->filterPrefix . '/' . $filter;
+        return $this->filterPrefix . '/' . ucfirst($filter);
     }
 }

--- a/library/Api/Customize/Config/CustomizeConfigInterface.php
+++ b/library/Api/Customize/Config/CustomizeConfigInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Config;
+
+interface CustomizeConfigInterface
+{
+    /**
+     * Theme mod key used to persist design token customization JSON.
+     */
+    public function getThemeModKey(): string;
+
+    /**
+     * Capability required to access the GET customize endpoint.
+     */
+    public function getGetPermissionCapability(): string;
+
+    /**
+     * Capability required to access the SAVE customize endpoint.
+     */
+    public function getSavePermissionCapability(): string;
+}

--- a/library/Api/Customize/Config/CustomizeConfigTest.php
+++ b/library/Api/Customize/Config/CustomizeConfigTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Config;
+
+use PHPUnit\Framework\TestCase;
+use WpService\Contracts\ApplyFilters;
+
+class CustomizeConfigTest extends TestCase
+{
+    public function testGetThemeModKeyReturnsDefaultWhenNotFiltered(): void
+    {
+        $wpService = new class implements ApplyFilters {
+            public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
+            {
+                return $value;
+            }
+        };
+
+        $config = new CustomizeConfig($wpService);
+
+        $this->assertSame('tokens', $config->getThemeModKey());
+    }
+
+    public function testGetThemeModKeyReturnsFilteredValue(): void
+    {
+        $wpService = new class implements ApplyFilters {
+            public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
+            {
+                return $hookName === 'Municipio/Api/Customize/getThemeModKey' ? 'custom_tokens' : $value;
+            }
+        };
+
+        $config = new CustomizeConfig($wpService);
+
+        $this->assertSame('custom_tokens', $config->getThemeModKey());
+    }
+
+    public function testGetThemeModKeyFallsBackToDefaultOnInvalidFilteredValue(): void
+    {
+        $wpService = new class implements ApplyFilters {
+            public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
+            {
+                return ['invalid'];
+            }
+        };
+
+        $config = new CustomizeConfig($wpService);
+
+        $this->assertSame('tokens', $config->getThemeModKey());
+    }
+
+    public function testGetPermissionCapabilityDefaultsToCurrentCapability(): void
+    {
+        $wpService = new class implements ApplyFilters {
+            public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
+            {
+                return $value;
+            }
+        };
+
+        $config = new CustomizeConfig($wpService);
+
+        $this->assertSame('edit_theme_options', $config->getGetPermissionCapability());
+    }
+
+    public function testSavePermissionCapabilityDefaultsToCurrentCapability(): void
+    {
+        $wpService = new class implements ApplyFilters {
+            public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
+            {
+                return $value;
+            }
+        };
+
+        $config = new CustomizeConfig($wpService);
+
+        $this->assertSame('edit_theme_options', $config->getSavePermissionCapability());
+    }
+
+    public function testGetPermissionCapabilityCanBeFiltered(): void
+    {
+        $wpService = new class implements ApplyFilters {
+            public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
+            {
+                return $hookName === 'Municipio/Api/Customize/getGetPermissionCapability' ? 'read' : $value;
+            }
+        };
+
+        $config = new CustomizeConfig($wpService);
+
+        $this->assertSame('read', $config->getGetPermissionCapability());
+    }
+
+    public function testSavePermissionCapabilityCanBeFiltered(): void
+    {
+        $wpService = new class implements ApplyFilters {
+            public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
+            {
+                return $hookName === 'Municipio/Api/Customize/getSavePermissionCapability' ? 'manage_options' : $value;
+            }
+        };
+
+        $config = new CustomizeConfig($wpService);
+
+        $this->assertSame('manage_options', $config->getSavePermissionCapability());
+    }
+
+    public function testGetPermissionCapabilityFallsBackToCurrentCapabilityOnInvalidFilteredValue(): void
+    {
+        $wpService = new class implements ApplyFilters {
+            public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
+            {
+                if ($hookName === 'Municipio/Api/Customize/getGetPermissionCapability') {
+                    return ['invalid'];
+                }
+
+                return $value;
+            }
+        };
+
+        $config = new CustomizeConfig($wpService);
+
+        $this->assertSame('edit_theme_options', $config->getGetPermissionCapability());
+    }
+
+    public function testSavePermissionCapabilityFallsBackToCurrentCapabilityOnInvalidFilteredValue(): void
+    {
+        $wpService = new class implements ApplyFilters {
+            public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
+            {
+                if ($hookName === 'Municipio/Api/Customize/getSavePermissionCapability') {
+                    return null;
+                }
+
+                return $value;
+            }
+        };
+
+        $config = new CustomizeConfig($wpService);
+
+        $this->assertSame('edit_theme_options', $config->getSavePermissionCapability());
+    }
+}

--- a/library/Api/Customize/Config/CustomizeConfigTest.php
+++ b/library/Api/Customize/Config/CustomizeConfigTest.php
@@ -28,7 +28,7 @@ class CustomizeConfigTest extends TestCase
         $wpService = new class implements ApplyFilters {
             public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
             {
-                return $hookName === 'Municipio/Api/Customize/getThemeModKey' ? 'custom_tokens' : $value;
+                return $hookName === 'Municipio/Api/Customize/GetThemeModKey' ? 'custom_tokens' : $value;
             }
         };
 
@@ -84,7 +84,7 @@ class CustomizeConfigTest extends TestCase
         $wpService = new class implements ApplyFilters {
             public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
             {
-                return $hookName === 'Municipio/Api/Customize/getGetPermissionCapability' ? 'read' : $value;
+                return $hookName === 'Municipio/Api/Customize/GetGetPermissionCapability' ? 'read' : $value;
             }
         };
 
@@ -98,7 +98,7 @@ class CustomizeConfigTest extends TestCase
         $wpService = new class implements ApplyFilters {
             public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
             {
-                return $hookName === 'Municipio/Api/Customize/getSavePermissionCapability' ? 'manage_options' : $value;
+                return $hookName === 'Municipio/Api/Customize/GetSavePermissionCapability' ? 'manage_options' : $value;
             }
         };
 
@@ -112,7 +112,7 @@ class CustomizeConfigTest extends TestCase
         $wpService = new class implements ApplyFilters {
             public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
             {
-                if ($hookName === 'Municipio/Api/Customize/getGetPermissionCapability') {
+                if ($hookName === 'Municipio/Api/Customize/GetGetPermissionCapability') {
                     return ['invalid'];
                 }
 
@@ -130,7 +130,7 @@ class CustomizeConfigTest extends TestCase
         $wpService = new class implements ApplyFilters {
             public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
             {
-                if ($hookName === 'Municipio/Api/Customize/getSavePermissionCapability') {
+                if ($hookName === 'Municipio/Api/Customize/GetSavePermissionCapability') {
                     return null;
                 }
 

--- a/library/Api/Customize/Get.php
+++ b/library/Api/Customize/Get.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize;
+
+use Municipio\Api\Customize\Config\CustomizeConfig;
+use Municipio\Api\Customize\Config\CustomizeConfigInterface;
+use Municipio\Api\RestApiEndpoint;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use WpService\Contracts\ApplyFilters;
+use WpService\Contracts\__;
+use WpService\Contracts\CurrentUserCan;
+use WpService\Contracts\GetThemeMod;
+use WpService\Contracts\RegisterRestRoute;
+
+/**
+ * REST endpoint for retrieving styleguide design token customizations.
+ */
+class Get extends RestApiEndpoint
+{
+    private const NAMESPACE = 'municipio/v1';
+    private const ROUTE = 'customize/design';
+    private readonly CustomizeConfigInterface $config;
+
+    public function __construct(
+        private readonly RegisterRestRoute&CurrentUserCan&GetThemeMod&ApplyFilters&__ $wpService,
+        ?CustomizeConfigInterface $config = null,
+    ) {
+        $this->config = $config ?? new CustomizeConfig($this->wpService);
+    }
+
+    /**
+     * Registers the REST route.
+     *
+     * @return bool True when route registration succeeded.
+     */
+    public function handleRegisterRestRoute(): bool
+    {
+        return $this->wpService->registerRestRoute(self::NAMESPACE, self::ROUTE, [
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => [$this, 'handleRequest'],
+            'permission_callback' => [$this, 'permissionCallback'],
+        ]);
+    }
+
+    /**
+     * Handles the REST request and returns decoded token customization data.
+     *
+     * @param WP_REST_Request $request The request object.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function handleRequest(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        $json = $this->readCustomizedDesignTokens();
+
+        if ($json === null) {
+            return new WP_REST_Response([], WP_Http::OK);
+        }
+
+        $decodedJson = json_decode($json, true);
+        if (!is_array($decodedJson)) {
+            return new WP_Error(
+                'invalid_customized_design_tokens',
+                $this->wpService->__('Design token customization data is invalid JSON.', 'municipio'),
+                ['status' => WP_Http::INTERNAL_SERVER_ERROR],
+            );
+        }
+
+        return new WP_REST_Response($decodedJson, WP_Http::OK);
+    }
+
+    /**
+     * Permission callback for design token endpoint.
+     *
+     * @return bool True when user can edit theme options.
+     */
+    public function permissionCallback(): bool
+    {
+        return $this->wpService->currentUserCan($this->config->getGetPermissionCapability());
+    }
+
+    /**
+     * Reads raw JSON from the styleguide customization file.
+     *
+     * @return string|null JSON string or null when unavailable.
+     */
+    protected function readCustomizedDesignTokens(): ?string
+    {
+        $customizations = $this->wpService->getThemeMod($this->config->getThemeModKey());
+        if (!is_string($customizations)) {
+            return null;
+        }
+
+        return $customizations;
+    }
+}

--- a/library/Api/Customize/Get.php
+++ b/library/Api/Customize/Get.php
@@ -12,8 +12,8 @@ use WP_Http;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
-use WpService\Contracts\ApplyFilters;
 use WpService\Contracts\__;
+use WpService\Contracts\ApplyFilters;
 use WpService\Contracts\CurrentUserCan;
 use WpService\Contracts\GetThemeMod;
 use WpService\Contracts\RegisterRestRoute;
@@ -25,6 +25,7 @@ class Get extends RestApiEndpoint
 {
     private const NAMESPACE = 'municipio/v1';
     private const ROUTE = 'customize/design';
+
     private readonly CustomizeConfigInterface $config;
 
     public function __construct(
@@ -86,7 +87,7 @@ class Get extends RestApiEndpoint
     }
 
     /**
-     * Reads raw JSON from the styleguide customization file.
+     * Reads design token customization JSON from theme mods.
      *
      * @return string|null JSON string or null when unavailable.
      */

--- a/library/Api/Customize/Get.php
+++ b/library/Api/Customize/Get.php
@@ -6,6 +6,9 @@ namespace Municipio\Api\Customize;
 
 use Municipio\Api\Customize\Config\CustomizeConfig;
 use Municipio\Api\Customize\Config\CustomizeConfigInterface;
+use Municipio\Api\Customize\Support\ChangesetIdResolver;
+use Municipio\Api\Customize\Support\CustomizeTokensReader;
+use Municipio\Api\Customize\Support\CustomizeTokensReaderInterface;
 use Municipio\Api\RestApiEndpoint;
 use WP_Error;
 use WP_Http;
@@ -29,16 +32,21 @@ class Get extends RestApiEndpoint
 {
     private const NAMESPACE = 'municipio/v1';
     private const ROUTE = 'customize/design';
-    private const CHANGESET_POST_TYPE = 'customize_changeset';
-    private const CHANGESET_QUERY_VAR = 'customize_changeset_uuid';
 
     private readonly CustomizeConfigInterface $config;
+    private readonly CustomizeTokensReaderInterface $tokensReader;
 
     public function __construct(
         private readonly RegisterRestRoute&CurrentUserCan&GetThemeMod&GetPostMeta&GetPosts&GetQueryVar&IsCustomizePreview&ApplyFilters&__ $wpService,
         ?CustomizeConfigInterface $config = null,
+        ?CustomizeTokensReaderInterface $tokensReader = null,
     ) {
         $this->config = $config ?? new CustomizeConfig($this->wpService);
+        $this->tokensReader = $tokensReader ?? new CustomizeTokensReader(
+            $this->wpService,
+            $this->config,
+            new ChangesetIdResolver($this->wpService),
+        );
     }
 
     /**
@@ -99,54 +107,6 @@ class Get extends RestApiEndpoint
      */
     protected function readCustomizedDesignTokens(WP_REST_Request $request): ?string
     {
-        $changesetId = $this->resolveChangesetId($request);
-        if ($changesetId !== null) {
-            $changesetCustomizations = $this->wpService->getPostMeta(
-                $changesetId,
-                $this->config->getThemeModKey(),
-                true,
-            );
-
-            if (is_string($changesetCustomizations)) {
-                return $changesetCustomizations;
-            }
-        }
-
-        $customizations = $this->wpService->getThemeMod($this->config->getThemeModKey());
-        if (!is_string($customizations)) {
-            return null;
-        }
-
-        return $customizations;
-    }
-
-    private function resolveChangesetId(WP_REST_Request $request): ?int
-    {
-        $changesetUuid = $request->get_param(self::CHANGESET_QUERY_VAR);
-        if ((!is_string($changesetUuid) || empty($changesetUuid)) && !$this->wpService->isCustomizePreview()) {
-            return null;
-        }
-
-        if (!is_string($changesetUuid) || empty($changesetUuid)) {
-            $changesetUuid = $this->wpService->getQueryVar(self::CHANGESET_QUERY_VAR, '');
-        }
-
-        if (!is_string($changesetUuid) || empty($changesetUuid)) {
-            return null;
-        }
-
-        $changesets = $this->wpService->getPosts([
-            'post_type'   => self::CHANGESET_POST_TYPE,
-            'name'        => $changesetUuid,
-            'post_status' => 'any',
-            'numberposts' => 1,
-            'fields'      => 'ids',
-        ]);
-
-        if (!isset($changesets[0]) || !is_numeric($changesets[0])) {
-            return null;
-        }
-
-        return (int) $changesets[0];
+        return $this->tokensReader->read($request);
     }
 }

--- a/library/Api/Customize/Get.php
+++ b/library/Api/Customize/Get.php
@@ -15,7 +15,11 @@ use WP_REST_Server;
 use WpService\Contracts\__;
 use WpService\Contracts\ApplyFilters;
 use WpService\Contracts\CurrentUserCan;
+use WpService\Contracts\GetPostMeta;
+use WpService\Contracts\GetPosts;
+use WpService\Contracts\GetQueryVar;
 use WpService\Contracts\GetThemeMod;
+use WpService\Contracts\IsCustomizePreview;
 use WpService\Contracts\RegisterRestRoute;
 
 /**
@@ -25,11 +29,13 @@ class Get extends RestApiEndpoint
 {
     private const NAMESPACE = 'municipio/v1';
     private const ROUTE = 'customize/design';
+    private const CHANGESET_POST_TYPE = 'customize_changeset';
+    private const CHANGESET_QUERY_VAR = 'customize_changeset_uuid';
 
     private readonly CustomizeConfigInterface $config;
 
     public function __construct(
-        private readonly RegisterRestRoute&CurrentUserCan&GetThemeMod&ApplyFilters&__ $wpService,
+        private readonly RegisterRestRoute&CurrentUserCan&GetThemeMod&GetPostMeta&GetPosts&GetQueryVar&IsCustomizePreview&ApplyFilters&__ $wpService,
         ?CustomizeConfigInterface $config = null,
     ) {
         $this->config = $config ?? new CustomizeConfig($this->wpService);
@@ -58,7 +64,7 @@ class Get extends RestApiEndpoint
      */
     public function handleRequest(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
-        $json = $this->readCustomizedDesignTokens();
+        $json = $this->readCustomizedDesignTokens($request);
 
         if ($json === null) {
             return new WP_REST_Response([], WP_Http::OK);
@@ -91,13 +97,56 @@ class Get extends RestApiEndpoint
      *
      * @return string|null JSON string or null when unavailable.
      */
-    protected function readCustomizedDesignTokens(): ?string
+    protected function readCustomizedDesignTokens(WP_REST_Request $request): ?string
     {
+        $changesetId = $this->resolveChangesetId($request);
+        if ($changesetId !== null) {
+            $changesetCustomizations = $this->wpService->getPostMeta(
+                $changesetId,
+                $this->config->getThemeModKey(),
+                true,
+            );
+
+            if (is_string($changesetCustomizations)) {
+                return $changesetCustomizations;
+            }
+        }
+
         $customizations = $this->wpService->getThemeMod($this->config->getThemeModKey());
         if (!is_string($customizations)) {
             return null;
         }
 
         return $customizations;
+    }
+
+    private function resolveChangesetId(WP_REST_Request $request): ?int
+    {
+        $changesetUuid = $request->get_param(self::CHANGESET_QUERY_VAR);
+        if ((!is_string($changesetUuid) || empty($changesetUuid)) && !$this->wpService->isCustomizePreview()) {
+            return null;
+        }
+
+        if (!is_string($changesetUuid) || empty($changesetUuid)) {
+            $changesetUuid = $this->wpService->getQueryVar(self::CHANGESET_QUERY_VAR, '');
+        }
+
+        if (!is_string($changesetUuid) || empty($changesetUuid)) {
+            return null;
+        }
+
+        $changesets = $this->wpService->getPosts([
+            'post_type'   => self::CHANGESET_POST_TYPE,
+            'name'        => $changesetUuid,
+            'post_status' => 'any',
+            'numberposts' => 1,
+            'fields'      => 'ids',
+        ]);
+
+        if (!isset($changesets[0]) || !is_numeric($changesets[0])) {
+            return null;
+        }
+
+        return (int) $changesets[0];
     }
 }

--- a/library/Api/Customize/GetTest.php
+++ b/library/Api/Customize/GetTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize;
+
+use PHPUnit\Framework\TestCase;
+use WpService\Contracts\__;
+use WpService\Contracts\ApplyFilters;
+use WpService\Contracts\CurrentUserCan;
+use WpService\Contracts\GetThemeMod;
+use WpService\Contracts\RegisterRestRoute;
+
+class GetTest extends TestCase
+{
+    public function testCanBeInstantiated(): void
+    {
+        $endpoint = new Get($this->getWpServiceMock(true));
+
+        $this->assertInstanceOf(Get::class, $endpoint);
+    }
+
+    public function testHandleRegisterRestRouteReturnsTrue(): void
+    {
+        $endpoint = new Get($this->getWpServiceMock(true));
+
+        $this->assertTrue($endpoint->handleRegisterRestRoute());
+    }
+
+    public function testPermissionCallbackReturnsCurrentUserCapability(): void
+    {
+        $endpointWithAccess = new Get($this->getWpServiceMock(true, true));
+        $endpointWithoutAccess = new Get($this->getWpServiceMock(true, false));
+
+        $this->assertTrue($endpointWithAccess->permissionCallback());
+        $this->assertFalse($endpointWithoutAccess->permissionCallback());
+    }
+
+    public function testHandleRequestReturnsDecodedJsonWhenFileContainsValidJson(): void
+    {
+        $endpoint = new class($this->getWpServiceMock(true)) extends Get {
+            protected function readCustomizedDesignTokens(): ?string
+            {
+                return '{"color":{"primary":"#005ea5"}}';
+            }
+        };
+
+        $response = $endpoint->handleRequest(new \WP_REST_Request('GET'));
+
+        $this->assertInstanceOf(\WP_REST_Response::class, $response);
+    }
+
+    public function testHandleRequestReturnsErrorWhenJsonIsInvalid(): void
+    {
+        $endpoint = new class($this->getWpServiceMock(true)) extends Get {
+            protected function readCustomizedDesignTokens(): ?string
+            {
+                return '{"invalid"';
+            }
+        };
+
+        $response = $endpoint->handleRequest(new \WP_REST_Request('GET'));
+
+        $this->assertInstanceOf(\WP_Error::class, $response);
+    }
+
+    public function testHandleRequestReturnsEmptyArrayWhenNoDataIsAvailable(): void
+    {
+        $endpoint = new class($this->getWpServiceMock(true)) extends Get {
+            protected function readCustomizedDesignTokens(): ?string
+            {
+                return null;
+            }
+        };
+
+        $response = $endpoint->handleRequest(new \WP_REST_Request('GET'));
+
+        $this->assertInstanceOf(\WP_REST_Response::class, $response);
+    }
+
+    private function getWpServiceMock(bool $registerRestRoute = true, bool $currentUserCan = true): RegisterRestRoute&CurrentUserCan&GetThemeMod&ApplyFilters&__
+    {
+        return new class($registerRestRoute, $currentUserCan) implements RegisterRestRoute, CurrentUserCan, GetThemeMod, ApplyFilters, __ {
+            public function __construct(
+                private bool $registerRestRoute,
+                private bool $currentUserCan,
+            ) {}
+
+            public function registerRestRoute(string $namespace, string $route, array $args = [], bool $override = false): bool
+            {
+                return $this->registerRestRoute;
+            }
+
+            public function currentUserCan(string $capability, mixed ...$args): bool
+            {
+                return $this->currentUserCan;
+            }
+
+            public function getThemeMod(string $name, mixed $defaultValue = false): mixed
+            {
+                return $defaultValue;
+            }
+
+            public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
+            {
+                return $value;
+            }
+
+            public function __(string $text, string $domain = 'default'): string
+            {
+                return $text;
+            }
+        };
+    }
+}

--- a/library/Api/Customize/GetTest.php
+++ b/library/Api/Customize/GetTest.php
@@ -101,8 +101,7 @@ class GetTest extends TestCase
         array $getPostsResponse = [],
         bool $isCustomizePreview = false,
         string $changesetUuidQueryVar = '',
-    ): RegisterRestRoute&CurrentUserCan&GetThemeMod&GetPostMeta&GetPosts&GetQueryVar&IsCustomizePreview&ApplyFilters&__
-    {
+    ): RegisterRestRoute&CurrentUserCan&GetThemeMod&GetPostMeta&GetPosts&GetQueryVar&IsCustomizePreview&ApplyFilters&__ {
         return new class(
             $registerRestRoute,
             $currentUserCan,
@@ -145,9 +144,7 @@ class GetTest extends TestCase
 
             public function getQueryVar(string $queryVar, mixed $defaultValue = ''): mixed
             {
-                return $queryVar === 'customize_changeset_uuid'
-                    ? $this->changesetUuidQueryVar
-                    : $defaultValue;
+                return $queryVar === 'customize_changeset_uuid' ? $this->changesetUuidQueryVar : $defaultValue;
             }
 
             public function isCustomizePreview(): bool

--- a/library/Api/Customize/GetTest.php
+++ b/library/Api/Customize/GetTest.php
@@ -8,7 +8,11 @@ use PHPUnit\Framework\TestCase;
 use WpService\Contracts\__;
 use WpService\Contracts\ApplyFilters;
 use WpService\Contracts\CurrentUserCan;
+use WpService\Contracts\GetPostMeta;
+use WpService\Contracts\GetPosts;
+use WpService\Contracts\GetQueryVar;
 use WpService\Contracts\GetThemeMod;
+use WpService\Contracts\IsCustomizePreview;
 use WpService\Contracts\RegisterRestRoute;
 
 class GetTest extends TestCase
@@ -39,7 +43,7 @@ class GetTest extends TestCase
     public function testHandleRequestReturnsDecodedJsonWhenFileContainsValidJson(): void
     {
         $endpoint = new class($this->getWpServiceMock(true)) extends Get {
-            protected function readCustomizedDesignTokens(): ?string
+            protected function readCustomizedDesignTokens(\WP_REST_Request $request): ?string
             {
                 return '{"color":{"primary":"#005ea5"}}';
             }
@@ -53,7 +57,7 @@ class GetTest extends TestCase
     public function testHandleRequestReturnsErrorWhenJsonIsInvalid(): void
     {
         $endpoint = new class($this->getWpServiceMock(true)) extends Get {
-            protected function readCustomizedDesignTokens(): ?string
+            protected function readCustomizedDesignTokens(\WP_REST_Request $request): ?string
             {
                 return '{"invalid"';
             }
@@ -67,7 +71,7 @@ class GetTest extends TestCase
     public function testHandleRequestReturnsEmptyArrayWhenNoDataIsAvailable(): void
     {
         $endpoint = new class($this->getWpServiceMock(true)) extends Get {
-            protected function readCustomizedDesignTokens(): ?string
+            protected function readCustomizedDesignTokens(\WP_REST_Request $request): ?string
             {
                 return null;
             }
@@ -78,12 +82,40 @@ class GetTest extends TestCase
         $this->assertInstanceOf(\WP_REST_Response::class, $response);
     }
 
-    private function getWpServiceMock(bool $registerRestRoute = true, bool $currentUserCan = true): RegisterRestRoute&CurrentUserCan&GetThemeMod&ApplyFilters&__
+    public function testHandleRequestReadsFromChangesetMeta(): void
     {
-        return new class($registerRestRoute, $currentUserCan) implements RegisterRestRoute, CurrentUserCan, GetThemeMod, ApplyFilters, __ {
+        $wpService = $this->getWpServiceMock(true, true, [999], true, '');
+        $endpoint = new Get($wpService);
+
+        $request = $this->createMock(\WP_REST_Request::class);
+        $request->method('get_param')->with('customize_changeset_uuid')->willReturn('abc-uuid');
+
+        $response = $endpoint->handleRequest($request);
+
+        $this->assertInstanceOf(\WP_REST_Response::class, $response);
+    }
+
+    private function getWpServiceMock(
+        bool $registerRestRoute = true,
+        bool $currentUserCan = true,
+        array $getPostsResponse = [],
+        bool $isCustomizePreview = false,
+        string $changesetUuidQueryVar = '',
+    ): RegisterRestRoute&CurrentUserCan&GetThemeMod&GetPostMeta&GetPosts&GetQueryVar&IsCustomizePreview&ApplyFilters&__
+    {
+        return new class(
+            $registerRestRoute,
+            $currentUserCan,
+            $getPostsResponse,
+            $isCustomizePreview,
+            $changesetUuidQueryVar,
+        ) implements RegisterRestRoute, CurrentUserCan, GetThemeMod, GetPostMeta, GetPosts, GetQueryVar, IsCustomizePreview, ApplyFilters, __ {
             public function __construct(
                 private bool $registerRestRoute,
                 private bool $currentUserCan,
+                private array $getPostsResponse,
+                private bool $isCustomizePreview,
+                private string $changesetUuidQueryVar,
             ) {}
 
             public function registerRestRoute(string $namespace, string $route, array $args = [], bool $override = false): bool
@@ -99,6 +131,28 @@ class GetTest extends TestCase
             public function getThemeMod(string $name, mixed $defaultValue = false): mixed
             {
                 return $defaultValue;
+            }
+
+            public function getPostMeta(int $postId, string $key = '', bool $single = false): mixed
+            {
+                return '{"color":{"primary":"#005ea5"}}';
+            }
+
+            public function getPosts(array $args = null): array
+            {
+                return $this->getPostsResponse;
+            }
+
+            public function getQueryVar(string $queryVar, mixed $defaultValue = ''): mixed
+            {
+                return $queryVar === 'customize_changeset_uuid'
+                    ? $this->changesetUuidQueryVar
+                    : $defaultValue;
+            }
+
+            public function isCustomizePreview(): bool
+            {
+                return $this->isCustomizePreview;
             }
 
             public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed

--- a/library/Api/Customize/README.md
+++ b/library/Api/Customize/README.md
@@ -113,3 +113,9 @@ For Customizer integrations:
 - Save endpoint: library/Api/Customize/Save.php
 - Config: library/Api/Customize/Config/CustomizeConfig.php
 - Config interface: library/Api/Customize/Config/CustomizeConfigInterface.php
+- Changeset resolver: library/Api/Customize/Support/ChangesetIdResolver.php
+- Changeset resolver interface: library/Api/Customize/Support/ChangesetIdResolverInterface.php
+- Tokens reader: library/Api/Customize/Support/CustomizeTokensReader.php
+- Tokens reader interface: library/Api/Customize/Support/CustomizeTokensReaderInterface.php
+- Tokens writer: library/Api/Customize/Support/CustomizeTokensWriter.php
+- Tokens writer interface: library/Api/Customize/Support/CustomizeTokensWriterInterface.php

--- a/library/Api/Customize/README.md
+++ b/library/Api/Customize/README.md
@@ -1,0 +1,115 @@
+# Customize API
+
+This feature exposes REST endpoints for reading and writing design token customizations.
+
+The implementation is Customizer-aware and supports WordPress changesets/revisions when used in a Customizer context.
+
+## Endpoints
+
+Namespace: municipio/v1
+
+Route: customize/design
+
+Methods:
+- GET: Read current token customization data.
+- POST: Save token customization data.
+
+## Request and Response
+
+### GET municipio/v1/customize/design
+
+Returns token customizations as a JSON object.
+
+If no customizations exist, an empty array is returned.
+
+If stored JSON is invalid, the endpoint returns WP_Error with code invalid_customized_design_tokens.
+
+### POST municipio/v1/customize/design
+
+Accepted payload formats:
+
+1. Direct object
+
+{
+	"color": {
+		"primary": "#005ea5"
+	}
+}
+
+2. Object wrapped in tokens
+
+{
+	"tokens": {
+		"color": {
+			"primary": "#005ea5"
+		}
+	}
+}
+
+Validation rules:
+- Payload must be a JSON object.
+- The resolved tokens value must be a JSON object.
+
+Error codes:
+- invalid_customized_design_tokens_payload
+- unable_to_encode_customized_design_tokens
+- unable_to_save_customized_design_tokens
+
+## Customizer Context and Revisions
+
+Both endpoints support changeset-aware behavior using customize_changeset_uuid.
+
+Changeset UUID source order:
+1. Request parameter customize_changeset_uuid
+2. Query var customize_changeset_uuid (when isCustomizePreview() is true)
+
+### GET behavior
+
+When a valid changeset is resolved:
+- Read customization JSON from changeset post meta first.
+
+Fallback:
+- If no changeset is found or no usable changeset meta exists, read from theme mod.
+
+### POST behavior
+
+When a valid changeset is resolved:
+- Save customization JSON to changeset post meta.
+- Trigger wpSavePostRevision(changesetId) after successful meta update.
+
+Fallback:
+- If no changeset is found, save to theme mod.
+
+## Configuration and Filters
+
+Configuration class:
+- Municipio\Api\Customize\Config\CustomizeConfig
+
+Filter prefix:
+- Municipio/Api/Customize
+
+Available filter keys:
+- Municipio/Api/Customize/GetThemeModKey
+- Municipio/Api/Customize/GetGetPermissionCapability
+- Municipio/Api/Customize/GetSavePermissionCapability
+
+Defaults:
+- Theme mod key: tokens
+- GET capability: edit_theme_options
+- POST capability: edit_theme_options
+
+All config values include fallback logic to defaults when a filtered value is invalid.
+
+## Integration Notes
+
+For Customizer integrations:
+- Include customize_changeset_uuid in API calls when available.
+- In preview/editor context, ensure requests include authentication/nonce as usual for REST requests.
+- Prefer saving through the changeset-aware flow to align with draft/publish behavior and revision history.
+
+## Source Files
+
+- Get endpoint: library/Api/Customize/Get.php
+- Save endpoint: library/Api/Customize/Save.php
+- Config: library/Api/Customize/Config/CustomizeConfig.php
+- Config interface: library/Api/Customize/Config/CustomizeConfigInterface.php

--- a/library/Api/Customize/Save.php
+++ b/library/Api/Customize/Save.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize;
+
+use Municipio\Api\Customize\Config\CustomizeConfig;
+use Municipio\Api\Customize\Config\CustomizeConfigInterface;
+use Municipio\Api\RestApiEndpoint;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use WpService\Contracts\ApplyFilters;
+use WpService\Contracts\CurrentUserCan;
+use WpService\Contracts\RegisterRestRoute;
+use WpService\Contracts\SetThemeMod;
+
+/**
+ * REST endpoint for saving styleguide design token customizations.
+ */
+class Save extends RestApiEndpoint
+{
+    private const NAMESPACE = 'municipio/v1';
+    private const ROUTE = 'customize/design';
+
+    private readonly CustomizeConfigInterface $config;
+
+    public function __construct(
+        private readonly RegisterRestRoute&CurrentUserCan&SetThemeMod&ApplyFilters $wpService,
+        ?CustomizeConfigInterface $config = null,
+    ) {
+        $this->config = $config ?? new CustomizeConfig($this->wpService);
+    }
+
+    /**
+     * Registers the REST route.
+     *
+     * @return bool True when route registration succeeded.
+     */
+    public function handleRegisterRestRoute(): bool
+    {
+        return $this->wpService->registerRestRoute(self::NAMESPACE, self::ROUTE, [
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => [$this, 'handleRequest'],
+            'permission_callback' => [$this, 'permissionCallback'],
+        ]);
+    }
+
+    /**
+     * Handles the REST request and persists token customization JSON.
+     *
+     * Accepts either { "tokens": { ... } } or a direct JSON object payload.
+     *
+     * @param WP_REST_Request $request The request object.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function handleRequest(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        $params = $request->get_json_params();
+        if (!is_array($params)) {
+            return $this->createBadRequestError('Payload must be a JSON object.');
+        }
+
+        $tokens = $params['tokens'] ?? $params;
+        if (!is_array($tokens)) {
+            return $this->createBadRequestError('Tokens must be a JSON object.');
+        }
+
+        $encodedTokens = json_encode($tokens);
+        if ($encodedTokens === false) {
+            $error = new WP_Error(
+                'unable_to_encode_customized_design_tokens',
+                'Unable to encode token customization data.',
+                ['status' => WP_Http::INTERNAL_SERVER_ERROR],
+            );
+
+            return $error;
+        }
+
+        $didSave = $this->wpService->setThemeMod($this->config->getThemeModKey(), $encodedTokens);
+        if (!$didSave) {
+            $error = new WP_Error(
+                'unable_to_save_customized_design_tokens',
+                'Unable to save token customization data.',
+                ['status' => WP_Http::INTERNAL_SERVER_ERROR],
+            );
+
+            return $error;
+        }
+
+        return new WP_REST_Response($tokens, WP_Http::OK);
+    }
+
+    /**
+     * Permission callback for design token endpoint.
+     *
+     * @return bool True when user can edit theme options.
+     */
+    public function permissionCallback(): bool
+    {
+        return $this->wpService->currentUserCan($this->config->getSavePermissionCapability());
+    }
+
+    private function createBadRequestError(string $message): WP_Error
+    {
+        return new WP_Error(
+            'invalid_customized_design_tokens_payload',
+            $message,
+            ['status' => WP_Http::BAD_REQUEST],
+        );
+    }
+}

--- a/library/Api/Customize/Save.php
+++ b/library/Api/Customize/Save.php
@@ -14,8 +14,13 @@ use WP_REST_Response;
 use WP_REST_Server;
 use WpService\Contracts\ApplyFilters;
 use WpService\Contracts\CurrentUserCan;
+use WpService\Contracts\GetPosts;
+use WpService\Contracts\GetQueryVar;
+use WpService\Contracts\IsCustomizePreview;
 use WpService\Contracts\RegisterRestRoute;
 use WpService\Contracts\SetThemeMod;
+use WpService\Contracts\UpdatePostMeta;
+use WpService\Contracts\WpSavePostRevision;
 
 /**
  * REST endpoint for saving styleguide design token customizations.
@@ -24,11 +29,13 @@ class Save extends RestApiEndpoint
 {
     private const NAMESPACE = 'municipio/v1';
     private const ROUTE = 'customize/design';
+    private const CHANGESET_POST_TYPE = 'customize_changeset';
+    private const CHANGESET_QUERY_VAR = 'customize_changeset_uuid';
 
     private readonly CustomizeConfigInterface $config;
 
     public function __construct(
-        private readonly RegisterRestRoute&CurrentUserCan&SetThemeMod&ApplyFilters $wpService,
+        private readonly RegisterRestRoute&CurrentUserCan&SetThemeMod&UpdatePostMeta&WpSavePostRevision&GetPosts&GetQueryVar&IsCustomizePreview&ApplyFilters $wpService,
         ?CustomizeConfigInterface $config = null,
     ) {
         $this->config = $config ?? new CustomizeConfig($this->wpService);
@@ -80,7 +87,21 @@ class Save extends RestApiEndpoint
             return $error;
         }
 
-        $didSave = $this->wpService->setThemeMod($this->config->getThemeModKey(), $encodedTokens);
+        $changesetId = $this->resolveChangesetId($request);
+        if ($changesetId !== null) {
+            $didSave = $this->wpService->updatePostMeta(
+                $changesetId,
+                $this->config->getThemeModKey(),
+                $encodedTokens,
+            );
+
+            if ($didSave !== false) {
+                $this->wpService->wpSavePostRevision($changesetId);
+            }
+        } else {
+            $didSave = $this->wpService->setThemeMod($this->config->getThemeModKey(), $encodedTokens);
+        }
+
         if (!$didSave) {
             $error = new WP_Error(
                 'unable_to_save_customized_design_tokens',
@@ -111,5 +132,35 @@ class Save extends RestApiEndpoint
             $message,
             ['status' => WP_Http::BAD_REQUEST],
         );
+    }
+
+    private function resolveChangesetId(WP_REST_Request $request): ?int
+    {
+        $changesetUuid = $request->get_param(self::CHANGESET_QUERY_VAR);
+        if ((!is_string($changesetUuid) || empty($changesetUuid)) && !$this->wpService->isCustomizePreview()) {
+            return null;
+        }
+
+        if (!is_string($changesetUuid) || empty($changesetUuid)) {
+            $changesetUuid = $this->wpService->getQueryVar(self::CHANGESET_QUERY_VAR, '');
+        }
+
+        if (!is_string($changesetUuid) || empty($changesetUuid)) {
+            return null;
+        }
+
+        $changesets = $this->wpService->getPosts([
+            'post_type'   => self::CHANGESET_POST_TYPE,
+            'name'        => $changesetUuid,
+            'post_status' => 'any',
+            'numberposts' => 1,
+            'fields'      => 'ids',
+        ]);
+
+        if (!isset($changesets[0]) || !is_numeric($changesets[0])) {
+            return null;
+        }
+
+        return (int) $changesets[0];
     }
 }

--- a/library/Api/Customize/Save.php
+++ b/library/Api/Customize/Save.php
@@ -6,6 +6,9 @@ namespace Municipio\Api\Customize;
 
 use Municipio\Api\Customize\Config\CustomizeConfig;
 use Municipio\Api\Customize\Config\CustomizeConfigInterface;
+use Municipio\Api\Customize\Support\ChangesetIdResolver;
+use Municipio\Api\Customize\Support\CustomizeTokensWriter;
+use Municipio\Api\Customize\Support\CustomizeTokensWriterInterface;
 use Municipio\Api\RestApiEndpoint;
 use WP_Error;
 use WP_Http;
@@ -29,16 +32,21 @@ class Save extends RestApiEndpoint
 {
     private const NAMESPACE = 'municipio/v1';
     private const ROUTE = 'customize/design';
-    private const CHANGESET_POST_TYPE = 'customize_changeset';
-    private const CHANGESET_QUERY_VAR = 'customize_changeset_uuid';
 
     private readonly CustomizeConfigInterface $config;
+    private readonly CustomizeTokensWriterInterface $tokensWriter;
 
     public function __construct(
         private readonly RegisterRestRoute&CurrentUserCan&SetThemeMod&UpdatePostMeta&WpSavePostRevision&GetPosts&GetQueryVar&IsCustomizePreview&ApplyFilters $wpService,
         ?CustomizeConfigInterface $config = null,
+        ?CustomizeTokensWriterInterface $tokensWriter = null,
     ) {
         $this->config = $config ?? new CustomizeConfig($this->wpService);
+        $this->tokensWriter = $tokensWriter ?? new CustomizeTokensWriter(
+            $this->wpService,
+            $this->config,
+            new ChangesetIdResolver($this->wpService),
+        );
     }
 
     /**
@@ -87,20 +95,7 @@ class Save extends RestApiEndpoint
             return $error;
         }
 
-        $changesetId = $this->resolveChangesetId($request);
-        if ($changesetId !== null) {
-            $didSave = $this->wpService->updatePostMeta(
-                $changesetId,
-                $this->config->getThemeModKey(),
-                $encodedTokens,
-            );
-
-            if ($didSave !== false) {
-                $this->wpService->wpSavePostRevision($changesetId);
-            }
-        } else {
-            $didSave = $this->wpService->setThemeMod($this->config->getThemeModKey(), $encodedTokens);
-        }
+        $didSave = $this->tokensWriter->write($request, $encodedTokens);
 
         if (!$didSave) {
             $error = new WP_Error(
@@ -132,35 +127,5 @@ class Save extends RestApiEndpoint
             $message,
             ['status' => WP_Http::BAD_REQUEST],
         );
-    }
-
-    private function resolveChangesetId(WP_REST_Request $request): ?int
-    {
-        $changesetUuid = $request->get_param(self::CHANGESET_QUERY_VAR);
-        if ((!is_string($changesetUuid) || empty($changesetUuid)) && !$this->wpService->isCustomizePreview()) {
-            return null;
-        }
-
-        if (!is_string($changesetUuid) || empty($changesetUuid)) {
-            $changesetUuid = $this->wpService->getQueryVar(self::CHANGESET_QUERY_VAR, '');
-        }
-
-        if (!is_string($changesetUuid) || empty($changesetUuid)) {
-            return null;
-        }
-
-        $changesets = $this->wpService->getPosts([
-            'post_type' => self::CHANGESET_POST_TYPE,
-            'name' => $changesetUuid,
-            'post_status' => 'any',
-            'numberposts' => 1,
-            'fields' => 'ids',
-        ]);
-
-        if (!isset($changesets[0]) || !is_numeric($changesets[0])) {
-            return null;
-        }
-
-        return (int) $changesets[0];
     }
 }

--- a/library/Api/Customize/Save.php
+++ b/library/Api/Customize/Save.php
@@ -150,11 +150,11 @@ class Save extends RestApiEndpoint
         }
 
         $changesets = $this->wpService->getPosts([
-            'post_type'   => self::CHANGESET_POST_TYPE,
-            'name'        => $changesetUuid,
+            'post_type' => self::CHANGESET_POST_TYPE,
+            'name' => $changesetUuid,
             'post_status' => 'any',
             'numberposts' => 1,
-            'fields'      => 'ids',
+            'fields' => 'ids',
         ]);
 
         if (!isset($changesets[0]) || !is_numeric($changesets[0])) {

--- a/library/Api/Customize/SaveTest.php
+++ b/library/Api/Customize/SaveTest.php
@@ -88,6 +88,58 @@ class SaveTest extends TestCase
         $this->assertInstanceOf(\WP_Error::class, $response);
     }
 
+    public function testHandleRequestReturnsErrorWhenPayloadIsNotObject(): void
+    {
+        $wpService = $this->getWpServiceMock(true, true, true);
+        $endpoint = new Save($wpService);
+
+        $request = $this->createMock(\WP_REST_Request::class);
+        $request
+            ->method('get_json_params')
+            ->willReturn('invalid-payload');
+
+        $response = $endpoint->handleRequest($request);
+
+        $this->assertInstanceOf(\WP_Error::class, $response);
+        $this->assertNull($wpService->savedName);
+    }
+
+    public function testHandleRequestReturnsErrorWhenTokensIsNotObject(): void
+    {
+        $wpService = $this->getWpServiceMock(true, true, true);
+        $endpoint = new Save($wpService);
+
+        $request = $this->createMock(\WP_REST_Request::class);
+        $request
+            ->method('get_json_params')
+            ->willReturn([
+                'tokens' => 'invalid-tokens',
+            ]);
+
+        $response = $endpoint->handleRequest($request);
+
+        $this->assertInstanceOf(\WP_Error::class, $response);
+        $this->assertNull($wpService->savedName);
+    }
+
+    public function testHandleRequestReturnsErrorWhenJsonEncodeFails(): void
+    {
+        $wpService = $this->getWpServiceMock(true, true, true);
+        $endpoint = new Save($wpService);
+
+        $request = $this->createMock(\WP_REST_Request::class);
+        $request
+            ->method('get_json_params')
+            ->willReturn([
+                'tokens' => ['invalid' => NAN],
+            ]);
+
+        $response = $endpoint->handleRequest($request);
+
+        $this->assertInstanceOf(\WP_Error::class, $response);
+        $this->assertNull($wpService->savedName);
+    }
+
     private function getWpServiceMock(bool $registerRestRoute, bool $currentUserCan, bool $setThemeMod): RegisterRestRoute&CurrentUserCan&SetThemeMod&ApplyFilters
     {
         return new class($registerRestRoute, $currentUserCan, $setThemeMod) implements RegisterRestRoute, CurrentUserCan, SetThemeMod, ApplyFilters {

--- a/library/Api/Customize/SaveTest.php
+++ b/library/Api/Customize/SaveTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize;
+
+use PHPUnit\Framework\TestCase;
+use WpService\Contracts\ApplyFilters;
+use WpService\Contracts\CurrentUserCan;
+use WpService\Contracts\RegisterRestRoute;
+use WpService\Contracts\SetThemeMod;
+
+class SaveTest extends TestCase
+{
+    public function testCanBeInstantiated(): void
+    {
+        $endpoint = new Save($this->getWpServiceMock(true, true, true));
+
+        $this->assertInstanceOf(Save::class, $endpoint);
+    }
+
+    public function testHandleRegisterRestRouteReturnsTrue(): void
+    {
+        $endpoint = new Save($this->getWpServiceMock(true, true, true));
+
+        $this->assertTrue($endpoint->handleRegisterRestRoute());
+    }
+
+    public function testPermissionCallbackReturnsCurrentUserCapability(): void
+    {
+        $endpointWithAccess = new Save($this->getWpServiceMock(true, true, true));
+        $endpointWithoutAccess = new Save($this->getWpServiceMock(true, false, true));
+
+        $this->assertTrue($endpointWithAccess->permissionCallback());
+        $this->assertFalse($endpointWithoutAccess->permissionCallback());
+    }
+
+    public function testHandleRequestSavesTokensFromTokensPayload(): void
+    {
+        $wpService = $this->getWpServiceMock(true, true, true);
+        $endpoint = new Save($wpService);
+
+        $request = $this->createMock(\WP_REST_Request::class);
+        $request
+            ->method('get_json_params')
+            ->willReturn([
+                'tokens' => ['color' => ['primary' => '#005ea5']],
+            ]);
+
+        $response = $endpoint->handleRequest($request);
+
+        $this->assertInstanceOf(\WP_REST_Response::class, $response);
+        $this->assertSame('tokens', $wpService->savedName);
+        $this->assertSame('{"color":{"primary":"#005ea5"}}', $wpService->savedValue);
+    }
+
+    public function testHandleRequestSavesTokensFromDirectObjectPayload(): void
+    {
+        $wpService = $this->getWpServiceMock(true, true, true);
+        $endpoint = new Save($wpService);
+
+        $request = $this->createMock(\WP_REST_Request::class);
+        $request
+            ->method('get_json_params')
+            ->willReturn([
+                'color' => ['primary' => '#005ea5'],
+            ]);
+
+        $response = $endpoint->handleRequest($request);
+
+        $this->assertInstanceOf(\WP_REST_Response::class, $response);
+        $this->assertSame('{"color":{"primary":"#005ea5"}}', $wpService->savedValue);
+    }
+
+    public function testHandleRequestReturnsErrorWhenSaveFails(): void
+    {
+        $endpoint = new Save($this->getWpServiceMock(true, true, false));
+
+        $request = $this->createMock(\WP_REST_Request::class);
+        $request
+            ->method('get_json_params')
+            ->willReturn([
+                'tokens' => ['color' => ['primary' => '#005ea5']],
+            ]);
+
+        $response = $endpoint->handleRequest($request);
+
+        $this->assertInstanceOf(\WP_Error::class, $response);
+    }
+
+    private function getWpServiceMock(bool $registerRestRoute, bool $currentUserCan, bool $setThemeMod): RegisterRestRoute&CurrentUserCan&SetThemeMod&ApplyFilters
+    {
+        return new class($registerRestRoute, $currentUserCan, $setThemeMod) implements RegisterRestRoute, CurrentUserCan, SetThemeMod, ApplyFilters {
+            public ?string $savedName = null;
+            public mixed $savedValue = null;
+
+            public function __construct(
+                private bool $registerRestRoute,
+                private bool $currentUserCan,
+                private bool $setThemeMod,
+            ) {}
+
+            public function registerRestRoute(string $routeNamespace, string $route, array $args = [], bool $override = false): bool
+            {
+                return $this->registerRestRoute;
+            }
+
+            public function currentUserCan(string $capability, mixed ...$args): bool
+            {
+                return $this->currentUserCan;
+            }
+
+            public function setThemeMod(string $name, mixed $value): bool
+            {
+                $this->savedName = $name;
+                $this->savedValue = $value;
+
+                return $this->setThemeMod;
+            }
+
+            public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed
+            {
+                return $value;
+            }
+        };
+    }
+}

--- a/library/Api/Customize/SaveTest.php
+++ b/library/Api/Customize/SaveTest.php
@@ -70,10 +70,7 @@ class SaveTest extends TestCase
             ->willReturn([
                 'tokens' => ['color' => ['primary' => '#005ea5']],
             ]);
-        $request
-            ->method('get_param')
-            ->with('customize_changeset_uuid')
-            ->willReturn('abc-uuid');
+        $request->method('get_param')->with('customize_changeset_uuid')->willReturn('abc-uuid');
 
         $response = $endpoint->handleRequest($request);
 
@@ -94,10 +91,7 @@ class SaveTest extends TestCase
             ->willReturn([
                 'tokens' => ['color' => ['primary' => '#005ea5']],
             ]);
-        $request
-            ->method('get_param')
-            ->with('customize_changeset_uuid')
-            ->willReturn('abc-uuid');
+        $request->method('get_param')->with('customize_changeset_uuid')->willReturn('abc-uuid');
 
         $response = $endpoint->handleRequest($request);
 
@@ -144,9 +138,7 @@ class SaveTest extends TestCase
         $endpoint = new Save($wpService);
 
         $request = $this->createMock(\WP_REST_Request::class);
-        $request
-            ->method('get_json_params')
-            ->willReturn('invalid-payload');
+        $request->method('get_json_params')->willReturn('invalid-payload');
 
         $response = $endpoint->handleRequest($request);
 
@@ -198,8 +190,7 @@ class SaveTest extends TestCase
         bool $updatePostMeta = true,
         bool $isCustomizePreview = false,
         string $changesetUuidQueryVar = '',
-    ): RegisterRestRoute&CurrentUserCan&SetThemeMod&UpdatePostMeta&WpSavePostRevision&GetPosts&GetQueryVar&IsCustomizePreview&ApplyFilters
-    {
+    ): RegisterRestRoute&CurrentUserCan&SetThemeMod&UpdatePostMeta&WpSavePostRevision&GetPosts&GetQueryVar&IsCustomizePreview&ApplyFilters {
         return new class(
             $registerRestRoute,
             $currentUserCan,
@@ -266,9 +257,7 @@ class SaveTest extends TestCase
 
             public function getQueryVar(string $queryVar, mixed $defaultValue = ''): mixed
             {
-                return $queryVar === 'customize_changeset_uuid'
-                    ? $this->changesetUuidQueryVar
-                    : $defaultValue;
+                return $queryVar === 'customize_changeset_uuid' ? $this->changesetUuidQueryVar : $defaultValue;
             }
 
             public function isCustomizePreview(): bool

--- a/library/Api/Customize/SaveTest.php
+++ b/library/Api/Customize/SaveTest.php
@@ -7,8 +7,13 @@ namespace Municipio\Api\Customize;
 use PHPUnit\Framework\TestCase;
 use WpService\Contracts\ApplyFilters;
 use WpService\Contracts\CurrentUserCan;
+use WpService\Contracts\GetPosts;
+use WpService\Contracts\GetQueryVar;
+use WpService\Contracts\IsCustomizePreview;
 use WpService\Contracts\RegisterRestRoute;
 use WpService\Contracts\SetThemeMod;
+use WpService\Contracts\UpdatePostMeta;
+use WpService\Contracts\WpSavePostRevision;
 
 class SaveTest extends TestCase
 {
@@ -52,6 +57,51 @@ class SaveTest extends TestCase
         $this->assertInstanceOf(\WP_REST_Response::class, $response);
         $this->assertSame('tokens', $wpService->savedName);
         $this->assertSame('{"color":{"primary":"#005ea5"}}', $wpService->savedValue);
+    }
+
+    public function testHandleRequestSavesTokensToChangesetMetaWhenChangesetUuidIsProvided(): void
+    {
+        $wpService = $this->getWpServiceMock(true, true, true, [123]);
+        $endpoint = new Save($wpService);
+
+        $request = $this->createMock(\WP_REST_Request::class);
+        $request
+            ->method('get_json_params')
+            ->willReturn([
+                'tokens' => ['color' => ['primary' => '#005ea5']],
+            ]);
+        $request
+            ->method('get_param')
+            ->with('customize_changeset_uuid')
+            ->willReturn('abc-uuid');
+
+        $response = $endpoint->handleRequest($request);
+
+        $this->assertInstanceOf(\WP_REST_Response::class, $response);
+        $this->assertSame(123, $wpService->updatedPostId);
+        $this->assertSame('tokens', $wpService->updatedMetaKey);
+        $this->assertSame(123, $wpService->revisionSavedForPostId);
+    }
+
+    public function testHandleRequestReturnsErrorWhenChangesetMetaSaveFails(): void
+    {
+        $wpService = $this->getWpServiceMock(true, true, true, [123], false);
+        $endpoint = new Save($wpService);
+
+        $request = $this->createMock(\WP_REST_Request::class);
+        $request
+            ->method('get_json_params')
+            ->willReturn([
+                'tokens' => ['color' => ['primary' => '#005ea5']],
+            ]);
+        $request
+            ->method('get_param')
+            ->with('customize_changeset_uuid')
+            ->willReturn('abc-uuid');
+
+        $response = $endpoint->handleRequest($request);
+
+        $this->assertInstanceOf(\WP_Error::class, $response);
     }
 
     public function testHandleRequestSavesTokensFromDirectObjectPayload(): void
@@ -140,16 +190,40 @@ class SaveTest extends TestCase
         $this->assertNull($wpService->savedName);
     }
 
-    private function getWpServiceMock(bool $registerRestRoute, bool $currentUserCan, bool $setThemeMod): RegisterRestRoute&CurrentUserCan&SetThemeMod&ApplyFilters
+    private function getWpServiceMock(
+        bool $registerRestRoute,
+        bool $currentUserCan,
+        bool $setThemeMod,
+        array $getPostsResponse = [],
+        bool $updatePostMeta = true,
+        bool $isCustomizePreview = false,
+        string $changesetUuidQueryVar = '',
+    ): RegisterRestRoute&CurrentUserCan&SetThemeMod&UpdatePostMeta&WpSavePostRevision&GetPosts&GetQueryVar&IsCustomizePreview&ApplyFilters
     {
-        return new class($registerRestRoute, $currentUserCan, $setThemeMod) implements RegisterRestRoute, CurrentUserCan, SetThemeMod, ApplyFilters {
+        return new class(
+            $registerRestRoute,
+            $currentUserCan,
+            $setThemeMod,
+            $getPostsResponse,
+            $updatePostMeta,
+            $isCustomizePreview,
+            $changesetUuidQueryVar,
+        ) implements RegisterRestRoute, CurrentUserCan, SetThemeMod, UpdatePostMeta, WpSavePostRevision, GetPosts, GetQueryVar, IsCustomizePreview, ApplyFilters {
             public ?string $savedName = null;
             public mixed $savedValue = null;
+            public ?int $updatedPostId = null;
+            public ?string $updatedMetaKey = null;
+            public mixed $updatedMetaValue = null;
+            public ?int $revisionSavedForPostId = null;
 
             public function __construct(
                 private bool $registerRestRoute,
                 private bool $currentUserCan,
                 private bool $setThemeMod,
+                private array $getPostsResponse,
+                private bool $updatePostMeta,
+                private bool $isCustomizePreview,
+                private string $changesetUuidQueryVar,
             ) {}
 
             public function registerRestRoute(string $routeNamespace, string $route, array $args = [], bool $override = false): bool
@@ -168,6 +242,38 @@ class SaveTest extends TestCase
                 $this->savedValue = $value;
 
                 return $this->setThemeMod;
+            }
+
+            public function updatePostMeta(int $postId, string $metaKey, mixed $metaValue, mixed $prevValue = ''): int|bool
+            {
+                $this->updatedPostId = $postId;
+                $this->updatedMetaKey = $metaKey;
+                $this->updatedMetaValue = $metaValue;
+
+                return $this->updatePostMeta;
+            }
+
+            public function wpSavePostRevision(int $postId): mixed
+            {
+                $this->revisionSavedForPostId = $postId;
+                return $postId;
+            }
+
+            public function getPosts(array $args = null): array
+            {
+                return $this->getPostsResponse;
+            }
+
+            public function getQueryVar(string $queryVar, mixed $defaultValue = ''): mixed
+            {
+                return $queryVar === 'customize_changeset_uuid'
+                    ? $this->changesetUuidQueryVar
+                    : $defaultValue;
+            }
+
+            public function isCustomizePreview(): bool
+            {
+                return $this->isCustomizePreview;
             }
 
             public function applyFilters(string $hookName, mixed $value, mixed ...$args): mixed

--- a/library/Api/Customize/Support/ChangesetIdResolver.php
+++ b/library/Api/Customize/Support/ChangesetIdResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Support;
+
+use WP_REST_Request;
+use WpService\Contracts\GetPosts;
+use WpService\Contracts\GetQueryVar;
+use WpService\Contracts\IsCustomizePreview;
+
+class ChangesetIdResolver implements ChangesetIdResolverInterface
+{
+    private const CHANGESET_POST_TYPE = 'customize_changeset';
+    private const CHANGESET_QUERY_VAR = 'customize_changeset_uuid';
+
+    public function __construct(
+        private readonly GetPosts&GetQueryVar&IsCustomizePreview $wpService,
+    ) {}
+
+    /**
+     * Resolve customize_changeset post ID from request/query context.
+     */
+    public function resolve(WP_REST_Request $request): ?int
+    {
+        $changesetUuid = $request->get_param(self::CHANGESET_QUERY_VAR);
+        if ((!is_string($changesetUuid) || empty($changesetUuid)) && !$this->wpService->isCustomizePreview()) {
+            return null;
+        }
+
+        if (!is_string($changesetUuid) || empty($changesetUuid)) {
+            $changesetUuid = $this->wpService->getQueryVar(self::CHANGESET_QUERY_VAR, '');
+        }
+
+        if (!is_string($changesetUuid) || empty($changesetUuid)) {
+            return null;
+        }
+
+        $changesets = $this->wpService->getPosts([
+            'post_type' => self::CHANGESET_POST_TYPE,
+            'name' => $changesetUuid,
+            'post_status' => 'any',
+            'numberposts' => 1,
+            'fields' => 'ids',
+        ]);
+
+        if (!isset($changesets[0]) || !is_numeric($changesets[0])) {
+            return null;
+        }
+
+        return (int) $changesets[0];
+    }
+}

--- a/library/Api/Customize/Support/ChangesetIdResolverInterface.php
+++ b/library/Api/Customize/Support/ChangesetIdResolverInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Support;
+
+use WP_REST_Request;
+
+interface ChangesetIdResolverInterface
+{
+    /**
+     * Resolve customize_changeset post ID from request/query context.
+     */
+    public function resolve(WP_REST_Request $request): ?int;
+}

--- a/library/Api/Customize/Support/ChangesetIdResolverTest.php
+++ b/library/Api/Customize/Support/ChangesetIdResolverTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Support;
+
+use PHPUnit\Framework\TestCase;
+use WpService\Contracts\GetPosts;
+use WpService\Contracts\GetQueryVar;
+use WpService\Contracts\IsCustomizePreview;
+
+class ChangesetIdResolverTest extends TestCase
+{
+    public function testResolveReturnsNullWhenNotInCustomizePreviewAndNoUuidInRequest(): void
+    {
+        $resolver = new ChangesetIdResolver($this->createWpService([], false, ''));
+        $request = $this->createRequestMock(null);
+
+        $this->assertNull($resolver->resolve($request));
+    }
+
+    public function testResolveReturnsChangesetIdFromRequestUuid(): void
+    {
+        $resolver = new ChangesetIdResolver($this->createWpService([123], false, ''));
+        $request = $this->createRequestMock('abc-uuid');
+
+        $this->assertSame(123, $resolver->resolve($request));
+    }
+
+    public function testResolveReturnsChangesetIdFromQueryVarInPreviewMode(): void
+    {
+        $resolver = new ChangesetIdResolver($this->createWpService([456], true, 'query-uuid'));
+        $request = $this->createRequestMock(null);
+
+        $this->assertSame(456, $resolver->resolve($request));
+    }
+
+    public function testResolveReturnsNullWhenMatchingChangesetCannotBeFound(): void
+    {
+        $resolver = new ChangesetIdResolver($this->createWpService([], true, 'query-uuid'));
+        $request = $this->createRequestMock(null);
+
+        $this->assertNull($resolver->resolve($request));
+    }
+
+    private function createRequestMock(?string $uuid): \WP_REST_Request
+    {
+        $request = $this->createMock(\WP_REST_Request::class);
+        $request->method('get_param')->with('customize_changeset_uuid')->willReturn($uuid);
+
+        return $request;
+    }
+
+    private function createWpService(
+        array $changesets,
+        bool $isCustomizePreview,
+        string $changesetQueryVar,
+    ): GetPosts&GetQueryVar&IsCustomizePreview {
+        return new class($changesets, $isCustomizePreview, $changesetQueryVar) implements GetPosts, GetQueryVar, IsCustomizePreview {
+            public function __construct(
+                private array $changesets,
+                private bool $isCustomizePreview,
+                private string $changesetQueryVar,
+            ) {}
+
+            public function getPosts(array $args = null): array
+            {
+                return $this->changesets;
+            }
+
+            public function getQueryVar(string $queryVar, mixed $defaultValue = ''): mixed
+            {
+                return $queryVar === 'customize_changeset_uuid' ? $this->changesetQueryVar : $defaultValue;
+            }
+
+            public function isCustomizePreview(): bool
+            {
+                return $this->isCustomizePreview;
+            }
+        };
+    }
+}

--- a/library/Api/Customize/Support/CustomizeTokensReader.php
+++ b/library/Api/Customize/Support/CustomizeTokensReader.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Support;
+
+use Municipio\Api\Customize\Config\CustomizeConfigInterface;
+use WP_REST_Request;
+use WpService\Contracts\GetPostMeta;
+use WpService\Contracts\GetThemeMod;
+
+class CustomizeTokensReader implements CustomizeTokensReaderInterface
+{
+    public function __construct(
+        private readonly GetThemeMod&GetPostMeta $wpService,
+        private readonly CustomizeConfigInterface $config,
+        private readonly ChangesetIdResolverInterface $changesetIdResolver,
+    ) {}
+
+    /**
+     * Read raw JSON customization payload for current request context.
+     */
+    public function read(WP_REST_Request $request): ?string
+    {
+        $changesetId = $this->changesetIdResolver->resolve($request);
+        if ($changesetId !== null) {
+            $changesetCustomizations = $this->wpService->getPostMeta(
+                $changesetId,
+                $this->config->getThemeModKey(),
+                true,
+            );
+
+            if (is_string($changesetCustomizations)) {
+                return $changesetCustomizations;
+            }
+        }
+
+        $customizations = $this->wpService->getThemeMod($this->config->getThemeModKey());
+        return is_string($customizations) ? $customizations : null;
+    }
+}

--- a/library/Api/Customize/Support/CustomizeTokensReaderInterface.php
+++ b/library/Api/Customize/Support/CustomizeTokensReaderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Support;
+
+use WP_REST_Request;
+
+interface CustomizeTokensReaderInterface
+{
+    /**
+     * Read raw JSON customization payload for current request context.
+     */
+    public function read(WP_REST_Request $request): ?string;
+}

--- a/library/Api/Customize/Support/CustomizeTokensReaderTest.php
+++ b/library/Api/Customize/Support/CustomizeTokensReaderTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Support;
+
+use Municipio\Api\Customize\Config\CustomizeConfigInterface;
+use PHPUnit\Framework\TestCase;
+use WpService\Contracts\GetPostMeta;
+use WpService\Contracts\GetThemeMod;
+
+class CustomizeTokensReaderTest extends TestCase
+{
+    public function testReadReturnsChangesetMetaWhenChangesetExists(): void
+    {
+        $wpService = $this->createWpService('theme-mod-value', '{"changeset":true}');
+        $config = $this->createConfig();
+        $resolver = $this->createResolver(999);
+        $reader = new CustomizeTokensReader($wpService, $config, $resolver);
+
+        $this->assertSame('{"changeset":true}', $reader->read($this->createMock(\WP_REST_Request::class)));
+    }
+
+    public function testReadFallsBackToThemeModWhenNoChangesetExists(): void
+    {
+        $wpService = $this->createWpService('{"theme":true}', '{"changeset":true}');
+        $config = $this->createConfig();
+        $resolver = $this->createResolver(null);
+        $reader = new CustomizeTokensReader($wpService, $config, $resolver);
+
+        $this->assertSame('{"theme":true}', $reader->read($this->createMock(\WP_REST_Request::class)));
+    }
+
+    public function testReadReturnsNullWhenNoStringPayloadExists(): void
+    {
+        $wpService = $this->createWpService(['invalid'], ['invalid']);
+        $config = $this->createConfig();
+        $resolver = $this->createResolver(100);
+        $reader = new CustomizeTokensReader($wpService, $config, $resolver);
+
+        $this->assertNull($reader->read($this->createMock(\WP_REST_Request::class)));
+    }
+
+    private function createConfig(): CustomizeConfigInterface
+    {
+        $config = $this->createMock(CustomizeConfigInterface::class);
+        $config->method('getThemeModKey')->willReturn('tokens');
+
+        return $config;
+    }
+
+    private function createResolver(?int $changesetId): ChangesetIdResolverInterface
+    {
+        $resolver = $this->createMock(ChangesetIdResolverInterface::class);
+        $resolver->method('resolve')->willReturn($changesetId);
+
+        return $resolver;
+    }
+
+    private function createWpService(mixed $themeModValue, mixed $postMetaValue): GetThemeMod&GetPostMeta
+    {
+        return new class($themeModValue, $postMetaValue) implements GetThemeMod, GetPostMeta {
+            public function __construct(
+                private mixed $themeModValue,
+                private mixed $postMetaValue,
+            ) {}
+
+            public function getThemeMod(string $name, mixed $defaultValue = false): mixed
+            {
+                return $this->themeModValue;
+            }
+
+            public function getPostMeta(int $postId, string $key = '', bool $single = false): mixed
+            {
+                return $this->postMetaValue;
+            }
+        };
+    }
+}

--- a/library/Api/Customize/Support/CustomizeTokensWriter.php
+++ b/library/Api/Customize/Support/CustomizeTokensWriter.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Support;
+
+use Municipio\Api\Customize\Config\CustomizeConfigInterface;
+use WP_REST_Request;
+use WpService\Contracts\SetThemeMod;
+use WpService\Contracts\UpdatePostMeta;
+use WpService\Contracts\WpSavePostRevision;
+
+class CustomizeTokensWriter implements CustomizeTokensWriterInterface
+{
+    public function __construct(
+        private readonly SetThemeMod&UpdatePostMeta&WpSavePostRevision $wpService,
+        private readonly CustomizeConfigInterface $config,
+        private readonly ChangesetIdResolverInterface $changesetIdResolver,
+    ) {}
+
+    /**
+     * Persist raw JSON customization payload for current request context.
+     */
+    public function write(WP_REST_Request $request, string $encodedTokens): bool
+    {
+        $changesetId = $this->changesetIdResolver->resolve($request);
+        if ($changesetId !== null) {
+            $didSave = $this->wpService->updatePostMeta(
+                $changesetId,
+                $this->config->getThemeModKey(),
+                $encodedTokens,
+            );
+
+            if ($didSave !== false) {
+                $this->wpService->wpSavePostRevision($changesetId);
+                return true;
+            }
+
+            return false;
+        }
+
+        return $this->wpService->setThemeMod($this->config->getThemeModKey(), $encodedTokens);
+    }
+}

--- a/library/Api/Customize/Support/CustomizeTokensWriterInterface.php
+++ b/library/Api/Customize/Support/CustomizeTokensWriterInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Support;
+
+use WP_REST_Request;
+
+interface CustomizeTokensWriterInterface
+{
+    /**
+     * Persist raw JSON customization payload for current request context.
+     */
+    public function write(WP_REST_Request $request, string $encodedTokens): bool;
+}

--- a/library/Api/Customize/Support/CustomizeTokensWriterTest.php
+++ b/library/Api/Customize/Support/CustomizeTokensWriterTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customize\Support;
+
+use Municipio\Api\Customize\Config\CustomizeConfigInterface;
+use PHPUnit\Framework\TestCase;
+use WpService\Contracts\SetThemeMod;
+use WpService\Contracts\UpdatePostMeta;
+use WpService\Contracts\WpSavePostRevision;
+
+class CustomizeTokensWriterTest extends TestCase
+{
+    public function testWriteStoresToChangesetAndSavesRevisionWhenChangesetExists(): void
+    {
+        $wpService = $this->createWpService(true, true);
+        $config = $this->createConfig();
+        $resolver = $this->createResolver(123);
+        $writer = new CustomizeTokensWriter($wpService, $config, $resolver);
+
+        $result = $writer->write($this->createMock(\WP_REST_Request::class), '{"a":1}');
+
+        $this->assertTrue($result);
+        $this->assertSame(123, $wpService->updatedPostId);
+        $this->assertSame(123, $wpService->revisionSavedForPostId);
+        $this->assertNull($wpService->savedName);
+    }
+
+    public function testWriteReturnsFalseWhenChangesetMetaWriteFails(): void
+    {
+        $wpService = $this->createWpService(true, false);
+        $config = $this->createConfig();
+        $resolver = $this->createResolver(123);
+        $writer = new CustomizeTokensWriter($wpService, $config, $resolver);
+
+        $result = $writer->write($this->createMock(\WP_REST_Request::class), '{"a":1}');
+
+        $this->assertFalse($result);
+        $this->assertNull($wpService->revisionSavedForPostId);
+    }
+
+    public function testWriteFallsBackToThemeModWhenNoChangesetExists(): void
+    {
+        $wpService = $this->createWpService(true, true);
+        $config = $this->createConfig();
+        $resolver = $this->createResolver(null);
+        $writer = new CustomizeTokensWriter($wpService, $config, $resolver);
+
+        $result = $writer->write($this->createMock(\WP_REST_Request::class), '{"a":1}');
+
+        $this->assertTrue($result);
+        $this->assertSame('tokens', $wpService->savedName);
+        $this->assertSame('{"a":1}', $wpService->savedValue);
+    }
+
+    private function createConfig(): CustomizeConfigInterface
+    {
+        $config = $this->createMock(CustomizeConfigInterface::class);
+        $config->method('getThemeModKey')->willReturn('tokens');
+
+        return $config;
+    }
+
+    private function createResolver(?int $changesetId): ChangesetIdResolverInterface
+    {
+        $resolver = $this->createMock(ChangesetIdResolverInterface::class);
+        $resolver->method('resolve')->willReturn($changesetId);
+
+        return $resolver;
+    }
+
+    private function createWpService(bool $setThemeModResult, bool $updatePostMetaResult): SetThemeMod&UpdatePostMeta&WpSavePostRevision
+    {
+        return new class($setThemeModResult, $updatePostMetaResult) implements SetThemeMod, UpdatePostMeta, WpSavePostRevision {
+            public ?string $savedName = null;
+            public mixed $savedValue = null;
+            public ?int $updatedPostId = null;
+            public ?string $updatedMetaKey = null;
+            public mixed $updatedMetaValue = null;
+            public ?int $revisionSavedForPostId = null;
+
+            public function __construct(
+                private bool $setThemeModResult,
+                private bool $updatePostMetaResult,
+            ) {}
+
+            public function setThemeMod(string $name, mixed $value): bool
+            {
+                $this->savedName = $name;
+                $this->savedValue = $value;
+
+                return $this->setThemeModResult;
+            }
+
+            public function updatePostMeta(int $postId, string $metaKey, mixed $metaValue, mixed $prevValue = ''): int|bool
+            {
+                $this->updatedPostId = $postId;
+                $this->updatedMetaKey = $metaKey;
+                $this->updatedMetaValue = $metaValue;
+
+                return $this->updatePostMetaResult;
+            }
+
+            public function wpSavePostRevision(int $postId): mixed
+            {
+                $this->revisionSavedForPostId = $postId;
+                return $postId;
+            }
+        };
+    }
+}

--- a/library/App.php
+++ b/library/App.php
@@ -237,6 +237,8 @@ class App
         RestApiEndpointsRegistry::add(new \Municipio\Api\PostsList\PostsListRender());
         RestApiEndpointsRegistry::add(new \Municipio\Api\PlaceSearch\PlaceSearchEndpoint($this->wpService));
         RestApiEndpointsRegistry::add(new \Municipio\Api\Nonce\Refresh());
+        RestApiEndpointsRegistry::add(new \Municipio\Api\Customize\Get($this->wpService));
+        RestApiEndpointsRegistry::add(new \Municipio\Api\Customize\Save($this->wpService));
 
         $pdfHelper = new \Municipio\Api\Pdf\PdfHelper();
         $pdfGenerator = new \Municipio\Api\Pdf\PdfGenerator($pdfHelper);


### PR DESCRIPTION
This pull request introduces a new REST API for managing styleguide design token customizations in the Municipio theme. It adds two new endpoints for retrieving and saving design token data, encapsulates configuration and permission logic, and provides comprehensive test coverage for the new functionality.

**New REST API Endpoints for Design Token Customization:**

* Added a `Get` endpoint (`library/Api/Customize/Get.php`) to fetch design token customizations, with permission checks and error handling for invalid or missing data.
* Added a `Save` endpoint (`library/Api/Customize/Save.php`) to persist design token customizations, supporting both wrapped (`{"tokens": {...}}`) and direct object payloads, with validation and error handling for payload and save failures.
* Registered both endpoints in the application's REST API endpoints registry (`library/App.php`).

**Configuration and Extensibility:**

* Introduced `CustomizeConfig` and `CustomizeConfigInterface` (`library/Api/Customize/Config/CustomizeConfig.php`, `library/Api/Customize/Config/CustomizeConfigInterface.php`) to centralize configuration (theme mod key, permission capabilities) and allow extensibility via WordPress filters. [[1]](diffhunk://#diff-e5f4174daf9b7aa8a8c78d19f6a7af7aaf55d6497ee04ed496953eec3061e736R1-R62) [[2]](diffhunk://#diff-3325bf6acc130a60b2550956a9a1bf13236d8adda7940d1f7ce6c269d1aea87fR1-R23)

**Testing and Reliability:**

* Added comprehensive unit tests for the endpoints and configuration logic, ensuring correct behavior, permission checks, error handling, and filter extensibility (`library/Api/Customize/GetTest.php`, `library/Api/Customize/SaveTest.php`, `library/Api/Customize/Config/CustomizeConfigTest.php`). [[1]](diffhunk://#diff-f7b8d2307a84f09394eaa4ef18df69d834478716c777f88a45429d32101b2257R1-R115) [[2]](diffhunk://#diff-d5b5917ac1ee6ee3a06efc66f4bc637027c8988215bbe157370b575908da8c93R1-R127) [[3]](diffhunk://#diff-7a8d601a7eb4fd770cdc610406931657e6d7c290379412893250bf60ca673262R1-R145)