### PR TITLE
Fix page-for-post-type navigation for flat post types

### DIFF
--- a/library/Controller/Navigation/Decorators/Menu/PageTreeAppendChildren.php
+++ b/library/Controller/Navigation/Decorators/Menu/PageTreeAppendChildren.php
@@ -209,7 +209,10 @@ class PageTreeAppendChildren implements MenuInterface
 
         //Check if posttype has content
         $pageForPostTypeIds = GetPageForPostTypeIds::getPageForPostTypeIds();
-        if (array_key_exists($postId, $pageForPostTypeIds)) {
+        if (
+            array_key_exists($postId, $pageForPostTypeIds) &&
+            is_post_type_hierarchical($pageForPostTypeIds[$postId])
+        ) {
             $postTypeHasPosts = $localWpdb->get_var(
                 $localWpdb->prepare("
                     SELECT ID

--- a/library/Controller/Navigation/Helper/GetPostsByParent.php
+++ b/library/Controller/Navigation/Helper/GetPostsByParent.php
@@ -28,8 +28,8 @@ class GetPostsByParent
      */
     public static function getPostsByParent(int|array $parent = 0, string|array $postType = 'page'): array
     {
-        //Check if if valid post type string
-        if ($postType != 'all' && !is_array($postType) && !post_type_exists($postType) && is_post_type_hierarchical($postType)) {
+        //Check if valid post type string
+        if ($postType != 'all' && !is_array($postType) && !self::isSupportedPostType($postType)) {
             return [];
         }
 
@@ -39,7 +39,7 @@ class GetPostsByParent
         if (is_array($postType)) {
             $stack = [];
             foreach ($postType as $item) {
-                if (post_type_exists($item) && is_post_type_hierarchical($item)) {
+                if (self::isSupportedPostType($item)) {
                     $stack[] = $item;
                 }
             }
@@ -58,7 +58,13 @@ class GetPostsByParent
 
         //Handle post type cases
         if ($postType == 'all') {
-            $postTypeSQL = "post_type IN('" . implode("', '", get_post_types(['public' => true])) . "')";
+            $postTypes = self::getHierarchicalPublicPostTypes();
+
+            if (empty($postTypes)) {
+                return [];
+            }
+
+            $postTypeSQL = "post_type IN('" . implode("', '", $postTypes) . "')";
         } elseif (is_array($postType)) {
             $postTypeSQL = "post_type IN('" . implode("', '", $postType) . "')";
         } else {
@@ -92,7 +98,11 @@ class GetPostsByParent
         $resultSet = $localWpdb->get_results($sql, ARRAY_A);
 
         foreach ($resultSet as &$item) {
-            if ($item['post_type'] != self::$masterPostType && $item['post_parent'] == 0) {
+            if (
+                $item['post_type'] != self::$masterPostType &&
+                $item['post_parent'] == 0 &&
+                self::isSupportedPostType($item['post_type'])
+            ) {
                 $pageForPostTypeIds = array_flip((array) GetPageForPostTypeIds::getPageForPostTypeIds());
 
                 if (array_key_exists($item['post_type'], $pageForPostTypeIds)) {
@@ -103,5 +113,30 @@ class GetPostsByParent
 
         //Run query
         return (array) $resultSet;
+    }
+
+    /**
+     * Check whether a post type can participate in page-tree navigation.
+     *
+     * @param string $postType The post type to check.
+     *
+     * @return bool True when the post type exists and is hierarchical.
+     */
+    private static function isSupportedPostType(string $postType): bool
+    {
+        return post_type_exists($postType) && is_post_type_hierarchical($postType);
+    }
+
+    /**
+     * Get public post types that can participate in page-tree navigation.
+     *
+     * @return array Public hierarchical post type names.
+     */
+    private static function getHierarchicalPublicPostTypes(): array
+    {
+        return array_values(array_filter(
+            (array) get_post_types(['public' => true]),
+            static fn (string $postType): bool => self::isSupportedPostType($postType)
+        ));
     }
 }

--- a/library/Helper/Navigation.php
+++ b/library/Helper/Navigation.php
@@ -239,7 +239,10 @@ class Navigation
 
         //Check if posttype has content
         $pageForPostTypeIds = $this->getPageForPostTypeIds();
-        if (array_key_exists($postId, $pageForPostTypeIds)) {
+        if (
+            array_key_exists($postId, $pageForPostTypeIds) &&
+            $this->isSupportedNavigationPostType($pageForPostTypeIds[$postId])
+        ) {
             $postTypeHasPosts = self::$db->get_var(
                 self::$db->prepare("
                     SELECT ID
@@ -344,8 +347,8 @@ class Navigation
      */
     private function getItems($parent = 0, $postType = 'page'): array
     {
-        //Check if if valid post type string
-        if ($postType != 'all' && !is_array($postType) && !post_type_exists($postType) && is_post_type_hierarchical($postType)) {
+        //Check if valid post type string
+        if ($postType != 'all' && !is_array($postType) && !$this->isSupportedNavigationPostType($postType)) {
             return [];
         }
 
@@ -353,7 +356,7 @@ class Navigation
         if (is_array($postType)) {
             $stack = [];
             foreach ($postType as $item) {
-                if (post_type_exists($item) && is_post_type_hierarchical($item)) {
+                if ($this->isSupportedNavigationPostType($item)) {
                     $stack[] = $item;
                 }
             }
@@ -372,7 +375,13 @@ class Navigation
 
         //Handle post type cases
         if ($postType == 'all') {
-            $postTypeSQL = "post_type IN('" . implode("', '", get_post_types(['public' => true])) . "')";
+            $postTypes = $this->getHierarchicalPublicPostTypes();
+
+            if (empty($postTypes)) {
+                return [];
+            }
+
+            $postTypeSQL = "post_type IN('" . implode("', '", $postTypes) . "')";
         } elseif (is_array($postType)) {
             $postTypeSQL = "post_type IN('" . implode("', '", $postType) . "')";
         } else {
@@ -399,7 +408,11 @@ class Navigation
         $resultSet = self::$db->get_results($sql, ARRAY_A);
 
         foreach ($resultSet as &$item) {
-            if ($item['post_type'] != $this->masterPostType && $item['post_parent'] == 0) {
+            if (
+                $item['post_type'] != $this->masterPostType &&
+                $item['post_parent'] == 0 &&
+                $this->isSupportedNavigationPostType($item['post_type'])
+            ) {
                 $pageForPostTypeIds = array_flip((array) $this->getPageForPostTypeIds());
 
                 if (array_key_exists($item['post_type'], $pageForPostTypeIds)) {
@@ -410,6 +423,31 @@ class Navigation
 
         //Run query
         return (array) $resultSet;
+    }
+
+    /**
+     * Check whether a post type can participate in page-tree navigation.
+     *
+     * @param string $postType The post type to check.
+     *
+     * @return bool True when the post type exists and is hierarchical.
+     */
+    private function isSupportedNavigationPostType(string $postType): bool
+    {
+        return post_type_exists($postType) && is_post_type_hierarchical($postType);
+    }
+
+    /**
+     * Get public post types that can participate in page-tree navigation.
+     *
+     * @return array Public hierarchical post type names.
+     */
+    private function getHierarchicalPublicPostTypes(): array
+    {
+        return array_values(array_filter(
+            (array) get_post_types(['public' => true]),
+            fn (string $postType): bool => $this->isSupportedNavigationPostType($postType)
+        ));
     }
 
 


### PR DESCRIPTION
## Summary

Fixes page-tree navigation so `page_for_{post_type}` pages do not automatically become virtual parents for non-hierarchical post types.

## Problem

The navigation logic treated archive page assignments and page-tree parentage as the same concept.

When a post type had a `page_for_{post_type}` option, Municipio could treat the assigned page as a parent container for top-level posts of that post type. This happened even when the post type was registered as non-hierarchical.

That is incorrect for page-tree navigation. A page can represent archive content without implying that individual posts belong under that page as menu children.

## Fix

Navigation child resolution now only includes post types that are registered and hierarchical.

This prevents non-hierarchical post types from being:

- resolved as page-tree children
- re-parented under their assigned archive page
- marked as having async submenu children through `page_for_{post_type}`

The existing archive/content behavior is unchanged. The `page_for_{post_type}` option can still be used for archive pages, templates, links, and content queries.