### PR TITLE
Fix ACF migration return type handling

### DIFF
--- a/Modularity/source/php/Upgrade/Migrators/Module/AcfModuleMigrationHandler.php
+++ b/Modularity/source/php/Upgrade/Migrators/Module/AcfModuleMigrationHandler.php
@@ -38,8 +38,10 @@ class AcfModuleMigrationHandler
 
         if (is_string($newField)) {
             $migrator = new AcfModuleFieldMigrator($newField, $oldFieldValue, $this->moduleId);
-            return $migrator->migrate();
+            return (bool) $migrator->migrate();
         }
+
+        return false;
     }
 
     private function migrateFieldByType(string $oldFieldName, $oldFieldValue, array $newField): bool
@@ -55,7 +57,7 @@ class AcfModuleMigrationHandler
             $migrator = new $class($newField, $oldFieldValue, $this->moduleId);
         }
 
-        return isset($migrator) ? $migrator->migrate() : false;
+        return isset($migrator) ? (bool) $migrator->migrate() : false;
     }
 
     private function isRemoveFieldMigration($newField)


### PR DESCRIPTION
## Summary

ACF field operations may return an updated record ID instead of a boolean. `AcfModuleMigrationHandler` forwarded those mixed values from methods declared to return `bool`, which triggers a `TypeError` under strict types after a successful update.

Normalize direct and typed migration results to boolean and explicitly return `false` for unsupported field definitions. Existing `true` and `false` results keep their meaning.

## Verification

- Reproduced the integer-return `TypeError` against commit `f029722` with an isolated check outside the upstream diff
- `composer test` — 1,398 tests, 2,209 assertions
- Mago semantic analysis reports no issues in the changed file
