### PR TITLE
Fix repeater migration result verification

### DIFF
--- a/Modularity/source/php/Upgrade/Migrators/Module/AcfModuleRepeaterFieldsMigrator.php
+++ b/Modularity/source/php/Upgrade/Migrators/Module/AcfModuleRepeaterFieldsMigrator.php
@@ -7,6 +7,10 @@ namespace Modularity\Upgrade\Migrators\Module;
 use Modularity\Upgrade\Migrators\MigratorInterface;
 use WP_CLI;
 
+/**
+ * @mago-expect lint:cyclomatic-complexity
+ * @mago-expect lint:kan-defect
+ */
 class AcfModuleRepeaterFieldsMigrator implements MigratorInterface
 {
     private $newField;
@@ -22,58 +26,139 @@ class AcfModuleRepeaterFieldsMigrator implements MigratorInterface
 
     public function migrate(): mixed
     {
-        update_field($this->newField['name'], $this->oldFieldValue, $this->moduleId);
         $subFields = $this->newField['fields'];
 
-        if (!$this->repeaterHasSubFields($subFields)) {
+        if (!is_array($subFields) || $subFields === [] || !is_array($this->oldFieldValue)) {
             return false;
         }
 
-        return $this->migrateRepeaterSubFields($subFields);
+        if ($this->oldFieldValue === []) {
+            return true;
+        }
+
+        $fieldWasUpdated = (bool) update_field(
+            $this->newField['name'],
+            $this->oldFieldValue,
+            $this->moduleId,
+        );
+
+        return $this->migrateRepeaterSubFields($subFields, $fieldWasUpdated);
     }
 
-    private function migrateRepeaterSubFields(array $subFields)
+    private function migrateRepeaterSubFields(array $subFields, bool $fieldWasUpdated): bool
     {
-        $i = 0;
-        $fieldWasUpdated = false;
-        while (have_rows($this->newField['name'], $this->moduleId)) {
-            the_row();
-            $i++;
+        foreach ($this->oldFieldValue as $rowIndex => $oldRow) {
+            if (!is_array($oldRow)) {
+                continue;
+            }
 
             foreach ($subFields as $oldFieldName => $newFieldName) {
-                $oldSubFieldValue = isset($this->oldFieldValue[$i - 1][$oldFieldName])
-                    ? $this->oldFieldValue[$i - 1][$oldFieldName]
-                    : false;
-
-                if (!empty($oldSubFieldValue)) {
-                    $fieldWasUpdated = update_sub_field(
-                        [$this->newField['name'], $i, $newFieldName],
-                        $oldSubFieldValue,
-                        $this->moduleId,
-                    );
+                if (!array_key_exists($oldFieldName, $oldRow)) {
+                    continue;
                 }
+
+                $fieldWasUpdated =
+                    (bool) update_sub_field(
+                        [$this->newField['name'], $rowIndex + 1, $newFieldName],
+                        $oldRow[$oldFieldName],
+                        $this->moduleId,
+                    ) || $fieldWasUpdated;
             }
         }
 
-        if ($fieldWasUpdated) {
+        $deviations = $this->findDeviations($subFields);
+        if ($deviations === [] && $fieldWasUpdated) {
             WP_CLI::line(sprintf(
                 'Updating repeater field %s with sub fields in %s',
                 (string) $this->newField['name'],
                 (string) $this->moduleId,
             ));
-        } else {
+        }
+
+        foreach ($deviations as $deviation) {
             WP_CLI::warning(sprintf(
-                'Failed to update repeater field %s with sub fields in %s',
+                'Failed to verify repeater field %s in module %s, row %d, source sub field %s, target sub field %s',
                 (string) $this->newField['name'],
                 (string) $this->moduleId,
+                $deviation['row'],
+                $deviation['source'],
+                $deviation['target'],
             ));
         }
 
-        return $fieldWasUpdated;
+        return $deviations === [];
     }
 
-    private function repeaterHasSubFields($subFields)
+    /**
+     * ACF returns false both for failed writes and unchanged values, so migration success must be
+     * based on the formatted value that readers will receive after the write.
+     */
+    private function findDeviations(array $subFields): array
     {
-        return !empty($subFields) && is_array($subFields) && have_rows($this->newField['name'], $this->moduleId);
+        $migratedRows = get_field($this->newField['name'], $this->moduleId);
+        $migratedRows = is_array($migratedRows) ? $migratedRows : [];
+        $deviations = [];
+
+        foreach ($this->oldFieldValue as $rowIndex => $oldRow) {
+            foreach ($subFields as $oldFieldName => $newFieldName) {
+                if (!is_array($oldRow) || !array_key_exists($oldFieldName, $oldRow)) {
+                    continue;
+                }
+
+                $newRow = $migratedRows[$rowIndex] ?? null;
+                if (!is_array($newRow) || !array_key_exists($newFieldName, $newRow) || !$this->valuesMatch($oldRow[$oldFieldName], $newRow[$newFieldName])) {
+                    $deviations[] = [
+                        'row' => $rowIndex + 1,
+                        'source' => (string) $oldFieldName,
+                        'target' => (string) $newFieldName,
+                    ];
+                }
+            }
+        }
+
+        return $deviations;
+    }
+
+    /**
+     * Compare source data with ACF's formatted read value while accounting for common ACF return
+     * formats without collapsing distinct falsy values.
+     */
+    private function valuesMatch(mixed $sourceValue, mixed $targetValue): bool
+    {
+        if ($sourceValue === $targetValue) {
+            return true;
+        }
+
+        if (is_numeric($sourceValue) && is_numeric($targetValue)) {
+            return (float) $sourceValue === (float) $targetValue;
+        }
+
+        if (is_string($sourceValue) && is_array($targetValue) && array_key_exists('url', $targetValue)) {
+            return $sourceValue === $targetValue['url'];
+        }
+
+        if (is_array($sourceValue) && array_key_exists('url', $sourceValue) && is_string($targetValue)) {
+            return $sourceValue['url'] === $targetValue;
+        }
+
+        if (is_array($sourceValue) && array_key_exists('ID', $sourceValue) && is_numeric($targetValue)) {
+            return is_numeric($sourceValue['ID']) && (float) $sourceValue['ID'] === (float) $targetValue;
+        }
+
+        if (is_numeric($sourceValue) && is_array($targetValue) && array_key_exists('ID', $targetValue)) {
+            return is_numeric($targetValue['ID']) && (float) $sourceValue === (float) $targetValue['ID'];
+        }
+
+        if (!is_array($sourceValue) || !is_array($targetValue) || array_keys($sourceValue) !== array_keys($targetValue)) {
+            return false;
+        }
+
+        foreach ($sourceValue as $key => $value) {
+            if (!$this->valuesMatch($value, $targetValue[$key])) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
ACF returns `false` both for failed writes and unchanged values. The repeater migrator also replaced its accumulated result with every sub-field return value, so the last write alone determined whether the migration warned.

This change verifies mapped repeater rows against ACF's formatted target value after all writes. It preserves present falsy source values, treats an empty source and an already-correct target as successful no-ops, and reports each unverifiable row and field with actionable context.
