### PR TITLE
Fix Modularity single post type admin links

### DIFF
--- a/Modularity/source/php/Options/SingleAdminPage.php
+++ b/Modularity/source/php/Options/SingleAdminPage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Modularity\Options;
 
+use WP_Post_Type;
+
 /**
  * Class SingleAdminPage
  *
@@ -11,6 +13,8 @@ namespace Modularity\Options;
  */
 class SingleAdminPage implements \Modularity\Options\AdminPageInterface
 {
+    private const MENU_SLUG_PREFIX = 'modularity-editor-single-';
+
     private array $postTypes;
 
     /**
@@ -30,6 +34,7 @@ class SingleAdminPage implements \Modularity\Options\AdminPageInterface
     public function addHooks(): void
     {
         add_action('admin_menu', [$this, 'addAdminPage'], 10);
+        add_filter('parent_file', [$this, 'setParentFile']);
     }
 
     /**
@@ -38,17 +43,108 @@ class SingleAdminPage implements \Modularity\Options\AdminPageInterface
     public function addAdminPage(): void
     {
         foreach ($this->postTypes as $postType) {
+            $postTypeObject = get_post_type_object($postType);
+
+            if (!$postTypeObject instanceof WP_Post_Type) {
+                continue;
+            }
+
             $postTypeUrlParam = '?post_type=' . $postType;
             $transcribedPostType = \Modularity\Editor::pageForPostTypeTranscribe('single-' . $postType);
-            $editorLink = "options.php?page=modularity-editor&id={$transcribedPostType}";
+            $menuSlug = self::MENU_SLUG_PREFIX . $postType;
 
-            add_submenu_page(
+            $hookName = add_submenu_page(
                 'edit.php' . $postTypeUrlParam,
                 __('Post type modules', 'municipio'),
                 __('Post type modules', 'municipio'),
-                'edit_posts',
-                $editorLink,
+                $postTypeObject->cap->edit_posts,
+                $menuSlug,
+                '__return_null',
             );
+
+            if ($hookName) {
+                add_action('load-' . $hookName, function () use ($transcribedPostType): void {
+                    $this->redirectToEditor($transcribedPostType);
+                });
+            }
         }
+    }
+
+    /**
+     * Keep the shared editor under its originating post type menu.
+     */
+    public function setParentFile(string $parentFile): string
+    {
+        global $plugin_page, $submenu, $submenu_file;
+
+        $postType = $this->getCurrentPostType();
+
+        if (!$postType) {
+            return $parentFile;
+        }
+
+        $menuSlug = self::MENU_SLUG_PREFIX . $postType;
+        $plugin_page = $menuSlug;
+
+        $selectedParent = $parentFile;
+        foreach ($submenu as $menuParent => $items) {
+            foreach ($items as $item) {
+                if ($this->isMenuItem($item[2], $menuSlug)) {
+                    $selectedParent = $menuParent;
+                    $submenu_file = $item[2];
+                }
+            }
+        }
+
+        // WordPress recalculates the parent after this filter. Remove stale
+        // copies left behind when another plugin has relocated the post type menu.
+        foreach ($submenu as $menuParent => &$items) {
+            if ($menuParent === $selectedParent) {
+                continue;
+            }
+
+            foreach ($items as $index => $item) {
+                if ($this->isMenuItem($item[2], $menuSlug)) {
+                    unset($items[$index]);
+                }
+            }
+        }
+        unset($items);
+
+        return $selectedParent;
+    }
+
+    /**
+     * A local submenu slug lets WordPress match the registered page hook before
+     * forwarding to the shared Modularity editor with the intended target ID.
+     */
+    private function redirectToEditor(string|int $editorId): never
+    {
+        wp_safe_redirect(
+            add_query_arg(
+                [
+                    'page' => 'modularity-editor',
+                    'id' => $editorId,
+                ],
+                admin_url('options.php'),
+            ),
+        );
+        exit();
+    }
+
+    private function getCurrentPostType(): ?string
+    {
+        if (!isset($_GET['page'], $_GET['id']) || $_GET['page'] !== 'modularity-editor' || !is_string($_GET['id']) || !str_starts_with($_GET['id'], 'single-')) {
+            return null;
+        }
+
+        $postType = substr($_GET['id'], 7);
+
+        return in_array($postType, $this->postTypes, true) ? $postType : null;
+    }
+
+    private function isMenuItem(string $menuItem, string $menuSlug): bool
+    {
+        return $menuItem === $menuSlug || str_ends_with($menuItem, 'page=' . $menuSlug);
     }
 }

--- a/Modularity/source/php/Options/SingleAdminPage.php
+++ b/Modularity/source/php/Options/SingleAdminPage.php
@@ -49,7 +49,7 @@ class SingleAdminPage implements \Modularity\Options\AdminPageInterface
                 continue;
             }
 
-            $postTypeUrlParam = '?post_type=' . $postType;
+            $postTypeUrlParam = $postType === 'post' ? '' : '?post_type=' . $postType;
             $transcribedPostType = \Modularity\Editor::pageForPostTypeTranscribe('single-' . $postType);
             $menuSlug = self::MENU_SLUG_PREFIX . $postType;
 


### PR DESCRIPTION
Single post type module menus currently use the full editor URL as their menu slug. For built-in and custom post types, that breaks WordPress admin-page matching and can leave users with a blank or inaccessible module view.

This registers a stable local submenu slug for each enabled post type, redirects from the page's early `load-*` hook to the shared Modularity editor, and preserves the originating parent and submenu context. Access continues to use each post type's existing edit capability without granting broader permissions.
