### PR TITLE
Fix custom post type archive slugs

### DIFF
--- a/library/AcfFields/php/options-theme-custom-post-type.php
+++ b/library/AcfFields/php/options-theme-custom-post-type.php
@@ -54,7 +54,7 @@
                     'name' => 'slug',
                     'aria-label' => '',
                     'type' => 'text',
-                    'instructions' => __('Public /url/ to show archive on.', 'municipio'),
+                    'instructions' => __('Public URL slug for the archive, without leading or trailing slashes.', 'municipio'),
                     'required' => 0,
                     'conditional_logic' => 0,
                     'wrapper' => array(

--- a/library/Content/CustomPostType.php
+++ b/library/Content/CustomPostType.php
@@ -15,6 +15,11 @@ class CustomPostType
             return $value;
         }, 10, 3);
 
+        // Keep stored and runtime rewrite slugs consistent with WordPress rewrite paths.
+        add_filter('acf/update_value/key=field_56b36c01e0619', static function ($value, $post_id, $field) {
+            return sanitize_title($value);
+        }, 10, 3);
+
         //Use page or single template
         add_filter('single_template', array($this, 'setPageTemplate'), 20);
 
@@ -73,13 +78,16 @@ class CustomPostType
             }
 
             $rewrite = ['with_front' => isset($typeDefinition['with_front']) ? $typeDefinition['with_front'] : true];
+            $slug = !empty($typeDefinition['slug'])
+                ? sanitize_title($typeDefinition['slug'])
+                : '';
 
-            if (!empty($typeDefinition['slug'])) {
-                $rewrite['slug'] = $typeDefinition['slug'];
+            if (!empty($slug)) {
+                $rewrite['slug'] = $slug;
             }
 
-            $restBase = !empty($typeDefinition['slug'])
-                ? sanitize_title($typeDefinition['slug'])
+            $restBase = !empty($slug)
+                ? $slug
                 : sanitize_title($typeDefinition['post_type_name']);
 
             $args = array(


### PR DESCRIPTION
Dynamic custom post type archive slugs are passed directly to WordPress rewrite registration. Values entered with leading or trailing slashes therefore generate rewrite rules that cannot match normal request paths, causing otherwise public archives to return 404.

This normalizes archive slugs when ACF saves them and again at runtime for existing values, while retaining the current fallback for empty slugs. The field guidance now makes the accepted format explicit.
