### PR TITLE
fix: make asset version removal configurable

### DIFF
--- a/library/Theme/Enqueue.php
+++ b/library/Theme/Enqueue.php
@@ -37,8 +37,14 @@ class Enqueue implements Hookable
             [$this, 'enqueueCustomizerScriptsAndStyles'],
             999,
         );
-        $this->wpService->addFilter('script_loader_src', [$this, 'removeScriptVersion'], 15, 1);
-        $this->wpService->addFilter('style_loader_src', [$this, 'removeScriptVersion'], 15, 1);
+        $removeScriptVersions = defined('MUNICIPIO_REMOVE_SCRIPT_VERSIONS')
+            ? (bool) constant('MUNICIPIO_REMOVE_SCRIPT_VERSIONS')
+            : true;
+
+        if ($this->wpService->applyFilters('municipio/remove_script_versions', $removeScriptVersions)) {
+            $this->wpService->addFilter('script_loader_src', [$this, 'removeScriptVersion'], 15, 1);
+            $this->wpService->addFilter('style_loader_src', [$this, 'removeScriptVersion'], 15, 1);
+        }
         $this->wpService->addFilter('the_generator', [$this, 'removeGeneratorTag'], 9, 2);
         $this->wpService->addAction('wp_default_scripts', [$this, 'removeJqueryMigrate']);
         $this->wpService->addFilter('gform_init_scripts_footer', [$this, 'forceGravityFormsScriptsNotInFooter']);


### PR DESCRIPTION
Municipio unconditionally registers filters that remove every query string from enqueued scripts and styles, preventing installations from retaining WordPress cache-busting versions.

This change keeps removal enabled by default while allowing a `MUNICIPIO_REMOVE_SCRIPT_VERSIONS` constant or the existing `municipio/remove_script_versions` filter to disable registration; URL handling remains unchanged when removal is enabled.