### PR TITLE
🐛 Bug(chat): presidio config null

### DIFF
--- a/library/Chat/Api/ChatEndpoint.php
+++ b/library/Chat/Api/ChatEndpoint.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-
 namespace Municipio\Chat\Api;
 
 use Municipio\Api\RestApiEndpoint;
 use Municipio\Chat\Config\ChatConfigInterface;
-use Municipio\Chat\PIIRedactor\PIIRedactorInterface;
+use Municipio\Chat\PIIRedactor\PIIRedactorFactoryInterface;
 use Municipio\Chat\PIIRedactor\RedactionResult;
 use WpService\Contracts\RegisterRestRoute;
 
@@ -18,7 +17,7 @@ class ChatEndpoint extends RestApiEndpoint
 
     public function __construct(
         private ChatConfigInterface $config,
-        private PIIRedactorInterface $piiRedactor,
+        private PIIRedactorFactoryInterface $piiRedactorFactory,
         private RegisterRestRoute $wpService,
     ) {}
 
@@ -37,12 +36,12 @@ class ChatEndpoint extends RestApiEndpoint
         $messageError = $this->validateMessage($params);
         if ($messageError instanceof \WP_Error) {
             return $messageError;
-            }
-            
-            $assistant = $this->resolveAssistant($params);
-            if ($assistant instanceof \WP_Error) {
-                return $assistant;
-                }
+        }
+
+        $assistant = $this->resolveAssistant($params);
+        if ($assistant instanceof \WP_Error) {
+            return $assistant;
+        }
 
         $configError = $this->validateAssistantConfig($assistant);
         if ($configError instanceof \WP_Error) {
@@ -82,7 +81,7 @@ class ChatEndpoint extends RestApiEndpoint
     private function resolveAssistant(array $params): array|\WP_Error
     {
         $assistantUniqueId = $params['assistant_name'] ?? null;
-        
+
         if (empty($assistantUniqueId) || $assistantUniqueId === 'Default') {
             return $this->config->getDefaultAssistant() ?? [];
         }
@@ -118,7 +117,7 @@ class ChatEndpoint extends RestApiEndpoint
     private function redactMessage(string $message): RedactionResult|\WP_Error
     {
         try {
-            return $this->piiRedactor->extractAndRedactPII($message);
+            return $this->piiRedactorFactory->create($this->config)->extractAndRedactPII($message);
         } catch (\Throwable $e) {
             $this->logRedactionError($e);
             return new \WP_Error(
@@ -149,7 +148,8 @@ class ChatEndpoint extends RestApiEndpoint
     private function registerSseStream(
         \WP_REST_Request $request,
         string $chatUrl,
-        #[\SensitiveParameter] string $apiKey,
+        #[\SensitiveParameter]
+        string $apiKey,
         array $body,
     ): void {
         add_filter(

--- a/library/Chat/Api/ChatEndpointTest.php
+++ b/library/Chat/Api/ChatEndpointTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 namespace Municipio\Chat\Api;
 
 use AcfService\Implementations\FakeAcfService;
@@ -10,20 +9,32 @@ use Municipio\Chat\Config\ChatConfig;
 use Municipio\Chat\Config\ChatConfigInterface;
 use Municipio\Chat\PIIRedactor\Exception\PIIRedactionException;
 use Municipio\Chat\PIIRedactor\Passthrough\PassthroughPIIRedactor;
+use Municipio\Chat\PIIRedactor\PIIRedactorFactoryInterface;
 use Municipio\Chat\PIIRedactor\PIIRedactorInterface;
 use Municipio\Chat\PIIRedactor\RedactionResult;
-
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use WpService\Contracts\RegisterRestRoute;
 use WpService\Implementations\FakeWpService;
+
+class MockPIIRedactorFactory implements PIIRedactorFactoryInterface
+{
+    public function __construct(
+        private $mockRedactor = null,
+    ) {}
+
+    public function create(ChatConfigInterface $config): PIIRedactorInterface
+    {
+        return $this->mockRedactor ?? new PassthroughPIIRedactor();
+    }
+}
 
 class ChatEndpointTest extends TestCase
 {
     #[TestDox('class can be instantiated')]
     public function testClassCanBeInstantiated(): void
     {
-        $endpoint = new ChatEndpoint($this->getConfig(), $this->getPIIRedactor(), static::createWpService());
+        $endpoint = new ChatEndpoint($this->getConfig(), $this->getPIIRedactorFactory(), static::createWpService());
 
         static::assertInstanceOf(ChatEndpoint::class, $endpoint);
     }
@@ -31,7 +42,7 @@ class ChatEndpointTest extends TestCase
     #[TestDox('handleRegisterRestRoute() returns true')]
     public function testHandleRegisterRestRouteCanBeCalled(): void
     {
-        $endpoint = new ChatEndpoint($this->getConfig(), $this->getPIIRedactor(), static::createWpService());
+        $endpoint = new ChatEndpoint($this->getConfig(), $this->getPIIRedactorFactory(), static::createWpService());
 
         static::assertTrue($endpoint->handleRegisterRestRoute());
     }
@@ -39,7 +50,7 @@ class ChatEndpointTest extends TestCase
     #[TestDox('handleRequest() returns a WP_Error when no message parameter is provided')]
     public function testHandleRequestReturnsErrorWhenMessageIsMissing(): void
     {
-        $endpoint = new ChatEndpoint($this->getConfig(), $this->getPIIRedactor(), static::createWpService());
+        $endpoint = new ChatEndpoint($this->getConfig(), $this->getPIIRedactorFactory(), static::createWpService());
         $request = $this->createRequest([]);
 
         $response = $endpoint->handleRequest($request);
@@ -50,7 +61,7 @@ class ChatEndpointTest extends TestCase
     #[TestDox('handleRequest() returns a WP_Error when the message parameter is empty')]
     public function testHandleRequestReturnsErrorWhenMessageIsEmpty(): void
     {
-        $endpoint = new ChatEndpoint($this->getConfig(), $this->getPIIRedactor(), static::createWpService());
+        $endpoint = new ChatEndpoint($this->getConfig(), $this->getPIIRedactorFactory(), static::createWpService());
         $request = $this->createRequest(['message' => '']);
 
         $response = $endpoint->handleRequest($request);
@@ -68,7 +79,7 @@ class ChatEndpointTest extends TestCase
             ],
         ]);
 
-        $endpoint = new ChatEndpoint($config, $this->getPIIRedactor(), static::createWpService());
+        $endpoint = new ChatEndpoint($config, $this->getPIIRedactorFactory(), static::createWpService());
         $request = $this->createRequest(['message' => 'Hello']);
 
         $response = $endpoint->handleRequest($request);
@@ -86,7 +97,7 @@ class ChatEndpointTest extends TestCase
             ],
         ]);
 
-        $endpoint = new ChatEndpoint($config, $this->getPIIRedactor(), static::createWpService());
+        $endpoint = new ChatEndpoint($config, $this->getPIIRedactorFactory(), static::createWpService());
         $request = $this->createRequest(['message' => 'Hello']);
 
         $response = $endpoint->handleRequest($request);
@@ -104,7 +115,7 @@ class ChatEndpointTest extends TestCase
             ],
         ]);
 
-        $endpoint = new ChatEndpoint($config, $this->getPIIRedactor(), static::createWpService());
+        $endpoint = new ChatEndpoint($config, $this->getPIIRedactorFactory(), static::createWpService());
         $request = $this->createRequest(['message' => 'Hello']);
 
         $response = $endpoint->handleRequest($request);
@@ -122,7 +133,7 @@ class ChatEndpointTest extends TestCase
             ],
         ]);
 
-        $endpoint = new ChatEndpoint($config, $this->getPIIRedactor(), static::createWpService());
+        $endpoint = new ChatEndpoint($config, $this->getPIIRedactorFactory(), static::createWpService());
         $request = $this->createRequest(['message' => 'Hello']);
 
         $response = $endpoint->handleRequest($request);
@@ -147,7 +158,9 @@ class ChatEndpointTest extends TestCase
             }
         };
 
-        $endpoint = new ChatEndpoint($config, $throwingRedactor, static::createWpService());
+        $throwingRedactorFactory = new MockPIIRedactorFactory($throwingRedactor);
+
+        $endpoint = new ChatEndpoint($config, $throwingRedactorFactory, static::createWpService());
         $request = $this->createRequest(['message' => 'Hello']);
 
         $response = $endpoint->handleRequest($request);
@@ -166,7 +179,7 @@ class ChatEndpointTest extends TestCase
             ],
         ]);
 
-        $endpoint = new ChatEndpoint($config, $this->getPIIRedactor(), static::createWpService());
+        $endpoint = new ChatEndpoint($config, $this->getPIIRedactorFactory(), static::createWpService());
         $request = $this->createRequest([
             'message' => 'Hello',
             'assistant_id' => 'explicit-id',
@@ -188,7 +201,7 @@ class ChatEndpointTest extends TestCase
     private function getConfig(array $fields = []): ChatConfigInterface
     {
         $acfService = new FakeAcfService([
-            'getField' => static fn (string $selector) => $fields[$selector] ?? null,
+            'getField' => static fn(string $selector) => $fields[$selector] ?? null,
         ]);
 
         $wpService = new FakeWpService(['determineLocale' => 'en_US']);
@@ -196,15 +209,14 @@ class ChatEndpointTest extends TestCase
         return new ChatConfig($wpService, $acfService);
     }
 
-    private function getPIIRedactor(): PIIRedactorInterface
+    private function getPIIRedactorFactory(): PIIRedactorFactoryInterface
     {
-        return new PassthroughPIIRedactor();
+        return new MockPIIRedactorFactory();
     }
 
     private static function createWpService(): RegisterRestRoute
     {
         return new class implements RegisterRestRoute {
-            
             public function registerRestRoute(string $routeNamespace, string $route, array $args = [], bool $override = false): bool
             {
                 return true;

--- a/library/Chat/ChatFeature.php
+++ b/library/Chat/ChatFeature.php
@@ -42,7 +42,7 @@ class ChatFeature
         $bladeRenderer = new BladeRenderer((new BladeServiceFactory($this->wpService))->create(ChatRender::getViewPathsDir()));
         $render = new ChatRender($bladeRenderer);
 
-        RestApiEndpointsRegistry::add(new ChatEndpoint($config, (new PIIRedactorFactory($this->wpService))->create($config), $this->wpService));
+        RestApiEndpointsRegistry::add(new ChatEndpoint($config, new PIIRedactorFactory($this->wpService), $this->wpService));
         RestApiEndpointsRegistry::add(new ChatStatsEndpoint($this->wpService));
 
         // Acf repeater crashes when below are reigstered


### PR DESCRIPTION
Instantiate redactor instance later during request; wait until ACF is loaded otherwise config is null.