### PR TITLE
Filter standard header presentation values

### DIFF
--- a/views/v3/partials/navigation/tabs.blade.php
+++ b/views/v3/partials/navigation/tabs.blade.php
@@ -7,13 +7,13 @@
         'allowStyle' => true,
         'buttonColor' => $customizer->tabmenuButtonColor,
         'buttonStyle' => $customizer->tabmenuButtonType,
-        'height' => 'sm',
-        'classList' => [
+        'height' => apply_filters('Municipio/Hook/headerSecondaryNavigationTabsHeight', 'sm', $customizer),
+        'classList' => apply_filters('Municipio/Hook/headerSecondaryNavigationTabsClass', [
             'u-width--auto',
             'u-display--none@xs',
             'u-display--none@sm',
             'u-display--none@md'
-        ]
+        ], $customizer)
     ])
     @endnav
 @endif

--- a/views/v3/partials/search/hero-search-form.blade.php
+++ b/views/v3/partials/search/hero-search-form.blade.php
@@ -1,3 +1,11 @@
+@php
+    $searchPlaceholder = apply_filters(
+        'Municipio/Search/Hero_search_placeholder',
+        $lang->searchOn . " " . $siteName,
+        $customizer
+    );
+@endphp
+
 @form([
     'id'        => 'hero-search-form',
     'method'    => 'get',
@@ -15,8 +23,8 @@
             'type' => 'search',
             'name' => 's',
             'required' => false,
-            'label' => $lang->searchOn . " " . $siteName,
-            'placeholder' => $lang->searchOn . " " . $siteName,
+            'label' => $searchPlaceholder,
+            'placeholder' => $searchPlaceholder,
             'size' => 'lg',
             'icon' => [
                 'icon' => 'search', 


### PR DESCRIPTION
The standard header hardcodes the tab menu's responsive classes and height, while the hero search template builds its label and placeholder directly. Extensions therefore have to replace Municipio templates to adjust these presentation values.

This change exposes the existing values through focused filters and passes the current Customizer data as context. The defaults, markup, components, and behavior remain unchanged when no filter is registered.
