### PR TITLE
fix(KulturKortet): validating tickets (+ developer impersonation)

### DIFF
--- a/library/Kulturkortet/Vitec/VitecConfig.php
+++ b/library/Kulturkortet/Vitec/VitecConfig.php
@@ -8,7 +8,9 @@ use AcfService\Contracts\GetField;
 
 class VitecConfig implements VitecConfigInterface
 {
-    public function __construct(private GetField $acfService) {}
+    public function __construct(
+        private GetField $acfService,
+    ) {}
 
     public function getBaseUrl(): string
     {
@@ -38,5 +40,13 @@ class VitecConfig implements VitecConfigInterface
         }
 
         return '';
+    }
+
+    public function mapSSN(string $ssn): string
+    {
+        if (defined('VITEC_IMPERSONATE_SSN') && !empty(VITEC_IMPERSONATE_SSN)) {
+            return VitecSSN::formatSSN(VITEC_IMPERSONATE_SSN);
+        }
+        return VitecSSN::formatSSN($ssn);
     }
 }

--- a/library/Kulturkortet/Vitec/VitecConfigInterface.php
+++ b/library/Kulturkortet/Vitec/VitecConfigInterface.php
@@ -9,4 +9,6 @@ interface VitecConfigInterface
     public function getBaseUrl(): string;
 
     public function getApiKey(): string;
+
+    public function mapSSN(string $ssn): string;
 }

--- a/library/Kulturkortet/Vitec/VitecService.php
+++ b/library/Kulturkortet/Vitec/VitecService.php
@@ -20,7 +20,7 @@ class VitecService implements VitecServiceInterface
     public function tryGetTicket(string $ssn): ?array
     {
         // For testing purposes, allow overriding the SSN with a known cardholder
-        $url = $this->config->getBaseUrl() . '/kulturkortet/customer/' . VitecSSN::formatSSN($ssn) . '/tickets';
+        $url = $this->config->getBaseUrl() . '/kulturkortet/customer/' . $this->config->mapSSN($ssn) . '/tickets';
 
         $response = $this->wpService->wpRemoteGet($url, [
             'headers' => [
@@ -34,13 +34,7 @@ class VitecService implements VitecServiceInterface
 
         $decodedBody = json_decode($body, true, flags: JSON_OBJECT_AS_ARRAY);
 
-        $ticket = array_values(
-            array_filter(
-                $decodedBody['tickets'] ?? [],
-                fn($t) => $t['ticketTemplateName'] === 'Import_Kulturkort')
-            )[0] ?? null;
-
-        return $ticket ?? null;
+        return VitecTickets::tryGetActiveTicket($decodedBody['tickets'] ?? []) ?? null;
     }
 
     public function updateUserData(string $ssn, string $email): ?array

--- a/library/Kulturkortet/Vitec/VitecTicketTest.php
+++ b/library/Kulturkortet/Vitec/VitecTicketTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Kulturkortet\Vitec;
+
+use DateTime;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertTrue;
+
+class VitecTicketTest extends TestCase
+{
+    private function makeTestTicket(int $id, string $ticketTemplateName, int $validFromDays, int $validUntilDays): array
+    {
+        $validFrom = (new \DateTime())
+            ->modify("{$validFromDays} days")
+            ->format('c');
+        $validUntil = (new \DateTime())
+            ->modify("{$validUntilDays} days")
+            ->format('c');
+
+        return [
+            'id' => $id,
+            'ticketTemplateName' => $ticketTemplateName,
+            'validFrom' => $validFrom,
+            'validUntil' => $validUntil,
+        ];
+    }
+
+    #[TestDox('ticketTemplateName must contain Import_Kulturkort')]
+    public function testTicketTemplateNameContainsImportKulturkort(): void
+    {
+        $tickets = [
+            $this->makeTestTicket(1, 'Evenemang', -10, 10),
+            $this->makeTestTicket(2, 'Import_Kulturkort kanske med extra kampanj', -10, +10),
+        ];
+
+        $activeTicket = VitecTickets::tryGetActiveTicket($tickets);
+        assertTrue(is_array($activeTicket));
+        assertEquals($activeTicket['id'], 2);
+        assertEquals($activeTicket['ticketTemplateName'], 'Import_Kulturkort kanske med extra kampanj');
+    }
+
+    #[TestDox('current date must be within the validFrom and validUntil range')]
+    public function testCurrentDateWithinValidRange(): void
+    {
+        $tickets = [
+            $this->makeTestTicket(1, 'Evenemang', -10, 10),
+            $this->makeTestTicket(2, 'Import_Kulturkort utgången', -20, -5),
+            $this->makeTestTicket(3, 'Import_Kulturkort giltig', -20, +20),
+            $this->makeTestTicket(4, 'Import_Kulturkort giltig men redundant', -20, +20),
+            $this->makeTestTicket(5, 'Import_Kulturkort framtida', +20, +40),
+            $this->makeTestTicket(6, 'Import_Kulturkort utgången', -20, -5),
+        ];
+
+        $activeTicket = VitecTickets::tryGetActiveTicket($tickets);
+        assertTrue(is_array($activeTicket));
+        assertEquals($activeTicket['id'], 3);
+    }
+}

--- a/library/Kulturkortet/Vitec/VitecTickets.php
+++ b/library/Kulturkortet/Vitec/VitecTickets.php
@@ -18,13 +18,12 @@ class VitecTickets
     public static function tryGetActiveTicket(array $tickets): ?array
     {
         $now = new \DateTime();
-        return (
+        return 
             array_values(
                 array_filter(
                     $tickets ?? [],
                     fn($t) => str_contains($t['ticketTemplateName'], 'Import_Kulturkort') && !empty($t['validFrom'] ?? '') && !empty($t['validUntil'] ?? '') && new \DateTime($t['validFrom'] ?? '') <= $now && new \DateTime($t['validUntil'] ?? '') >= $now,
                 ),
-            )[0] ?? null
-        );
+            )[0] ?? null;
     }
 }

--- a/library/Kulturkortet/Vitec/VitecTickets.php
+++ b/library/Kulturkortet/Vitec/VitecTickets.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Kulturkortet\Vitec;
+
+class VitecTickets
+{
+    /**
+     * Try to get the active ticket from the list of tickets.
+     * To be active,
+     * - the ticket must have 'Import_Kulturkort' in its template name
+     * - the current date must be within the validFrom and validUntil range
+     *
+     * @param array $tickets List of tickets to check.
+     * @return array|null The active ticket if found, otherwise null.
+     */
+    public static function tryGetActiveTicket(array $tickets): ?array
+    {
+        $now = new \DateTime();
+        return (
+            array_values(
+                array_filter(
+                    $tickets ?? [],
+                    fn($t) => str_contains($t['ticketTemplateName'], 'Import_Kulturkort') && !empty($t['validFrom'] ?? '') && !empty($t['validUntil'] ?? '') && new \DateTime($t['validFrom'] ?? '') <= $now && new \DateTime($t['validUntil'] ?? '') >= $now,
+                ),
+            )[0] ?? null
+        );
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@helsingborg-stad/municipio",
-    "version": "7.11.4",
+    "version": "7.12.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@helsingborg-stad/municipio",
-            "version": "7.11.4",
+            "version": "7.12.9",
             "license": "MIT",
             "dependencies": {
                 "@types/markdown-it": "^14.1.2",


### PR DESCRIPTION
This pull request refactors how active tickets are identified in the Vitec integration and introduces improved test coverage. The main change is the creation of a dedicated `VitecTickets` utility class to encapsulate the logic for selecting an active ticket, replacing inline filtering. Additionally, a new test suite ensures the ticket selection logic works as intended. There are also small interface and constructor signature updates to support these changes.

**Ticket selection logic improvements:**

* Introduced the `VitecTickets` class with a static `tryGetActiveTicket` method that selects an active ticket by checking if the ticket template name contains `'Import_Kulturkort'` and if the current date is within the ticket's valid range.
* Updated `VitecService::tryGetTicket` to use `VitecTickets::tryGetActiveTicket` instead of inline filtering, simplifying and centralizing the logic.

**Testing enhancements:**

* Added `VitecTicketTest` with tests for the ticket template name and validity date range, ensuring correct identification of active tickets.

**Interface and constructor changes:**

* Added the `mapSSN` method to `VitecConfig` and its interface, allowing for SSN overriding (e.g., for testing or impersonation). [[1]](diffhunk://#diff-65509012afc716c88383ea8a6b96db07c1854b62c5cd3acde59b2ee761927d02R44-R51) [[2]](diffhunk://#diff-e38314e7a75d7be0ce92d1c1cafcf14c66afd80820e3527443ab0a4af9f6ad43R12-R13)
* Updated `VitecService` to use the new `mapSSN` method when constructing ticket URLs, supporting SSN overrides.
* Minor formatting adjustment in the `VitecConfig` constructor signature for consistency.