### PR TITLE
fix: reject invalid intermediate images

### DIFF
--- a/library/Helper/File.php
+++ b/library/Helper/File.php
@@ -30,8 +30,8 @@ class File
                 "SELECT post_id FROM `$wpdb->postmeta`
                 WHERE `meta_key` LIKE '_wp_attached_file'
                 AND `meta_value` LIKE '%$filename%'
-                LIMIT 1"
-            )
+                LIMIT 1",
+            ),
         );
         if (!empty($meta)) {
             return \wp_get_attachment_url($meta[0]);
@@ -56,7 +56,7 @@ class File
         }
 
         // Build cache key + group
-        $key   = md5($filePath);
+        $key = hash('sha512', $filePath);
         $group = 'municipio_file_exists_cache';
 
         $wpService = WpService::get();
@@ -73,6 +73,7 @@ class File
                 self::$runtimeFileExistsCache[$filePath] = false;
                 return false;
             }
+
             // If unexpected value, fall through and re-check filesystem
         }
 
@@ -110,7 +111,7 @@ class File
     public static function getImageSize($filePath, $expireFound = 0, $expireNotFound = 86400)
     {
         //Unique cache value
-        $uid = "municipio_get_image_size_cache_" . md5($filePath);
+        $uid = 'municipio_get_image_size_cache_' . hash('sha512', $filePath);
 
         //If in cahce, found
         if ($cachedValue = wp_cache_get($uid)) {
@@ -126,6 +127,52 @@ class File
         //Opsie, file not found
         wp_cache_set($uid, false, '', $expireNotFound);
         return false;
+    }
+
+    /**
+     * Determine whether a file is a complete image with the expected properties.
+     *
+     * Image editors may leave an empty or partially written file behind when a
+     * conversion fails. Existence alone must therefore never be used as proof
+     * that an image can be served.
+     */
+    public static function isValidImage(
+        string $filePath,
+        ?string $expectedMimeType = null,
+        ?int $expectedWidth = null,
+        ?int $expectedHeight = null,
+    ): bool {
+        clearstatcache(true, $filePath);
+
+        $imageSize = is_file($filePath) && filesize($filePath) > 0 ? self::getImageSizeWithoutWarnings($filePath) : false;
+
+        return $imageSize !== false && ($expectedMimeType === null || ($imageSize['mime'] ?? null) === $expectedMimeType) && ($expectedWidth === null || $imageSize[0] === $expectedWidth) && ($expectedHeight === null || $imageSize[1] === $expectedHeight);
+    }
+
+    /**
+     * Read image metadata without leaking warnings for malformed files.
+     */
+    public static function getImageSizeWithoutWarnings(string $filePath): array|false
+    {
+        set_error_handler(static fn(): bool => true);
+
+        try {
+            return getimagesize($filePath);
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    public static function getImageMimeTypeForPath(string $filePath): ?string
+    {
+        return match (strtolower(pathinfo($filePath, PATHINFO_EXTENSION))) {
+            'gif' => 'image/gif',
+            'jpg', 'jpeg' => 'image/jpeg',
+            'png' => 'image/png',
+            'tif', 'tiff' => 'image/tiff',
+            'webp' => 'image/webp',
+            default => null,
+        };
     }
 
     /**
@@ -145,7 +192,7 @@ class File
     public static function getMimeType($filePath)
     {
         //Unique cache value
-        $uid = "municipio_get_mime_cache_" . md5($filePath);
+        $uid = 'municipio_get_mime_cache_' . hash('sha512', $filePath);
 
         //If in cahce, found
         if ($cachedValue = wp_cache_get($uid)) {

--- a/library/Helper/FileTest.php
+++ b/library/Helper/FileTest.php
@@ -7,10 +7,23 @@ use WpService\Implementations\FakeWpService;
 
 class FileTest extends TestCase
 {
+    private array $temporaryFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryFiles as $temporaryFile) {
+            if (file_exists($temporaryFile)) {
+                unlink($temporaryFile);
+            }
+        }
+
+        parent::tearDown();
+    }
+
     #[TestDox('fileExists should return true for an existing file')]
     public function testFileExistsReturnsTrueForExistingFile()
     {
-        $filePath  = __FILE__; // This file.
+        $filePath = __FILE__; // This file.
         $wpService = new FakeWpService(['wpCacheGet' => false, 'wpCacheSet' => true]);
         WpService::set($wpService);
         $this->assertTrue(File::fileExists($filePath));
@@ -19,7 +32,7 @@ class FileTest extends TestCase
     #[TestDox('fileExists should return false for a non-existing file')]
     public function testFileExistsReturnsFalseForNonExistingFile()
     {
-        $filePath  = __DIR__ . '/non_existing_file.txt'; // A file that does not exist.
+        $filePath = __DIR__ . '/non_existing_file.txt'; // A file that does not exist.
         $wpService = new FakeWpService(['wpCacheGet' => false, 'wpCacheSet' => true]);
         WpService::set($wpService);
         $this->assertFalse(File::fileExists($filePath));
@@ -28,7 +41,7 @@ class FileTest extends TestCase
     #[TestDox('fileExists should cache the result for found files')]
     public function testFileExistsCachesFoundFiles()
     {
-        $filePath  = __FILE__; // This file.
+        $filePath = __FILE__; // This file.
         $wpService = new FakeWpService(['wpCacheGet' => false, 'wpCacheSet' => true]);
         WpService::set($wpService);
 
@@ -45,7 +58,7 @@ class FileTest extends TestCase
     #[TestDox('fileExists should cache the result for non-existing files')]
     public function testFileExistsCachesNonExistingFiles()
     {
-        $filePath  = __DIR__ . '/non_existing_file.txt'; // A file that does not exist.
+        $filePath = __DIR__ . '/non_existing_file.txt'; // A file that does not exist.
         $wpService = new FakeWpService(['wpCacheGet' => false, 'wpCacheSet' => true]);
         WpService::set($wpService);
 
@@ -62,7 +75,7 @@ class FileTest extends TestCase
     #[TestDox('fileExists should use runtime cache for repeated calls within same request')]
     public function testFileExistsUsesRuntimeCache()
     {
-        $filePath  = __FILE__; // This file.
+        $filePath = __FILE__; // This file.
         $wpService = new FakeWpService(['wpCacheGet' => false, 'wpCacheSet' => true]);
         WpService::set($wpService);
 
@@ -79,5 +92,49 @@ class FileTest extends TestCase
 
         // Should have same number of cache get calls (runtime cache prevented additional lookups)
         $this->assertEquals($firstCallCount, $secondCallCount);
+    }
+
+    #[TestDox('isValidImage should reject empty and malformed files')]
+    public function testIsValidImageRejectsInvalidFiles(): void
+    {
+        $emptyFile = $this->createTemporaryFile('');
+        $malformedFile = $this->createTemporaryFile('not an image');
+
+        $this->assertFalse(File::isValidImage($emptyFile));
+        $this->assertFalse(File::isValidImage($malformedFile));
+    }
+
+    #[TestDox('isValidImage should validate image type and dimensions')]
+    public function testIsValidImageValidatesExpectedProperties(): void
+    {
+        $imageFile = $this->createTemporaryFile(
+            base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', true),
+        );
+
+        $this->assertTrue(File::isValidImage($imageFile, 'image/png', 1, 1));
+        $this->assertFalse(File::isValidImage($imageFile, 'image/webp', 1, 1));
+        $this->assertFalse(File::isValidImage($imageFile, 'image/png', 2, 1));
+        $this->assertFalse(File::isValidImage($imageFile, 'image/png', 1, 2));
+    }
+
+    #[TestDox('getImageMimeTypeForPath should resolve supported file extensions')]
+    public function testGetImageMimeTypeForPathResolvesSupportedExtensions(): void
+    {
+        $this->assertSame('image/jpeg', File::getImageMimeTypeForPath('/uploads/image.JPG'));
+        $this->assertSame('image/webp', File::getImageMimeTypeForPath('/uploads/image.webp'));
+        $this->assertNull(File::getImageMimeTypeForPath('/uploads/image.unknown'));
+    }
+
+    private function createTemporaryFile(string $contents): string
+    {
+        $temporaryFile = tempnam(sys_get_temp_dir(), 'municipio-image-test-');
+        if ($temporaryFile === false) {
+            $this->fail('Could not create a temporary file.');
+        }
+
+        file_put_contents($temporaryFile, $contents);
+        $this->temporaryFiles[] = $temporaryFile;
+
+        return $temporaryFile;
     }
 }

--- a/library/ImageConvert/ImageProcessor.php
+++ b/library/ImageConvert/ImageProcessor.php
@@ -2,17 +2,18 @@
 
 namespace Municipio\ImageConvert;
 
-use Municipio\ImageConvert\Contract\ImageContract;
-use Municipio\ImageConvert\Config\ImageConvertConfig;
 use Municipio\Helper\File;
-use WpService\Contracts\WpGetImageEditor;
-use WpService\Contracts\IsWpError;
-use WpService\Contracts\WpGetAttachmentMetadata;
-use WpService\Contracts\WpAttachmentIs;
+use Municipio\ImageConvert\Cache\ConversionCache;
+use Municipio\ImageConvert\Config\ImageConvertConfig;
+use Municipio\ImageConvert\Contract\ImageContract;
+use Municipio\ImageConvert\Logging\Log;
 use WpService\Contracts\AddFilter;
 use WpService\Contracts\ApplyFilters;
-use Municipio\ImageConvert\Cache\ConversionCache;
-use Municipio\ImageConvert\Logging\Log;
+use WpService\Contracts\IsWpError;
+use WpService\Contracts\WpAttachmentIs;
+use WpService\Contracts\WpDeleteFile;
+use WpService\Contracts\WpGetAttachmentMetadata;
+use WpService\Contracts\WpGetImageEditor;
 
 /**
  * ImageProcessor
@@ -23,12 +24,11 @@ use Municipio\ImageConvert\Logging\Log;
 class ImageProcessor
 {
     public function __construct(
-        private WpGetImageEditor&IsWpError&WpGetAttachmentMetadata&WpAttachmentIs&AddFilter&ApplyFilters $wpService,
+        private WpGetImageEditor&IsWpError&WpGetAttachmentMetadata&WpAttachmentIs&AddFilter&ApplyFilters&WpDeleteFile $wpService,
         private ImageConvertConfig $config,
         private ConversionCache $conversionCache,
-        private Log $log
-    ) {
-    }
+        private Log $log,
+    ) {}
 
     /**
      * Process an image resize request
@@ -48,14 +48,7 @@ class ImageProcessor
             // Check if the image can be resized
             $canConvert = $this->canConvertImage($image);
             if ($canConvert instanceof \WP_Error) {
-                $this->log->log(
-                    $this,
-                    'Cannot convert image: ' . $canConvert->get_error_message(),
-                    'warning',
-                    ['image' => $image, 'format' => $format, 'reason' => $canConvert->get_error_code()]
-                );
-
-                $this->conversionCache->markConversionFailed($image);
+                $this->logConversionFailure($image, $format, $canConvert);
                 return false;
             }
 
@@ -64,7 +57,7 @@ class ImageProcessor
                 $this,
                 'Starting image conversion.',
                 'info',
-                ['image' => $image, 'format' => $format]
+                ['image' => $image, 'format' => $format],
             );
 
             // Set processing limits for better resource management
@@ -74,73 +67,114 @@ class ImageProcessor
             // Switch to the preferred image editor based on file type
             $this->setPreferredImageEditorByFiletype($image);
 
-            $intermediateLocation = $image->getIntermidiateLocation($format);
-
-            $imageEditor = $this->wpService->wpGetImageEditor($image->getPath());
-
-            if (!$this->wpService->isWpError($imageEditor)) {
-                // Get the original image dimensions
-                $originalSize = $imageEditor->get_size();
-
-                // Determine target dimensions using min() to avoid upscaling
-                $targetWidth  = min($image->getWidth(), $originalSize['width']);
-                $targetHeight = min($image->getHeight(), $originalSize['height']);
-
-                // Resize the image
-                $imageEditor->resize($targetWidth, $targetHeight, true);
-
-                // Attempt to save the resized image
-                $savedImage = $imageEditor->save($intermediateLocation['path']);
-
-                if (!$this->wpService->isWpError($savedImage)) {
-
-                    // Fire filter to allow modification of the final path
-                    $intermediateLocation['path'] = $this->wpService->applyFilters(
-                        'wp_create_file_in_uploads', 
-                        $intermediateLocation['path'],
-                        $image->getId() 
-                    );
-
-                    $image->setUrl($intermediateLocation['url']);
-                    $image->setPath($intermediateLocation['path']);
-
-                    // Mark conversion as successful
-                    $this->conversionCache->markConversionSuccess($image);
-
-                    $this->log->log(
-                        $this,
-                        'Successfully converted image.',
-                        'info',
-                        ['image' => $image, 'format' => $format]
-                    );
-
-                    return $image;
-                } else {
-                    $this->log->log(
-                        $this,
-                        'Cannot convert image: ' . $savedImage->get_error_message(),
-                        'warning',
-                        ['image' => $image, 'format' => $format, 'reason' => $savedImage->get_error_code()]
-                    );
-
-                    $this->conversionCache->markConversionFailed($image);
-                }
-            } else {
-                $this->log->log(
-                    $this,
-                    'Cannot convert image: ' . $imageEditor->get_error_message(),
-                    'warning',
-                    ['image' => $image, 'format' => $format, 'reason' => $imageEditor->get_error_code()]
-                );
-
-                $this->conversionCache->markConversionFailed($image);
-            }
-
-            return false;
+            return $this->convertImage($image, $format);
         } finally {
             // Always release the lock, even if resizing failed
             $this->conversionCache->releaseConversionLock($image);
         }
+    }
+
+    private function convertImage(ImageContract $image, string $format): ImageContract|false
+    {
+        $imageEditor = $this->wpService->wpGetImageEditor($image->getPath());
+        if ($this->wpService->isWpError($imageEditor)) {
+            $this->logConversionFailure($image, $format, $imageEditor);
+            return false;
+        }
+
+        $originalSize = $imageEditor->get_size();
+        $targetWidth = min($image->getWidth(), $originalSize['width']);
+        $targetHeight = min($image->getHeight(), $originalSize['height']);
+        $resizeResult = $imageEditor->resize($targetWidth, $targetHeight, true);
+
+        if ($this->wpService->isWpError($resizeResult)) {
+            $this->logConversionFailure($image, $format, $resizeResult);
+            return false;
+        }
+
+        $intermediateLocation = $image->getIntermidiateLocation($format);
+        $temporaryPath = $this->getTemporaryPath($intermediateLocation['path']);
+
+        try {
+            $savedImage = $imageEditor->save($temporaryPath);
+            if ($this->wpService->isWpError($savedImage)) {
+                $this->logConversionFailure($image, $format, $savedImage);
+                return false;
+            }
+
+            $savedPath = $savedImage['path'] ?? $temporaryPath;
+            $temporaryPath = $savedPath;
+
+            if (!File::isValidImage(
+                $savedPath,
+                File::getImageMimeTypeForPath($intermediateLocation['path']),
+                $targetWidth,
+                $targetHeight,
+            )) {
+                $this->logConversionFailure(
+                    $image,
+                    $format,
+                    new \WP_Error('invalid_output', 'The converted image is empty, malformed, or has unexpected properties.'),
+                );
+                return false;
+            }
+
+            if (!rename($savedPath, $intermediateLocation['path'])) {
+                $this->logConversionFailure(
+                    $image,
+                    $format,
+                    new \WP_Error('publish_failed', 'The converted image could not be moved to its public path.'),
+                );
+                return false;
+            }
+
+            $temporaryPath = null;
+
+            $intermediateLocation['path'] = $this->wpService->applyFilters(
+                'wp_create_file_in_uploads',
+                $intermediateLocation['path'],
+                $image->getId(),
+            );
+
+            $image->setUrl($intermediateLocation['url']);
+            $image->setPath($intermediateLocation['path']);
+            $this->conversionCache->markConversionSuccess($image);
+            $this->log->log(
+                $this,
+                'Successfully converted image.',
+                'info',
+                ['image' => $image, 'format' => $format],
+            );
+
+            return $image;
+        } finally {
+            if ($temporaryPath !== null && file_exists($temporaryPath)) {
+                $this->wpService->wpDeleteFile($temporaryPath);
+            }
+        }
+    }
+
+    /**
+     * Build a unique path beside the final image while preserving its extension.
+     */
+    private function getTemporaryPath(string $finalPath): string
+    {
+        $extension = pathinfo($finalPath, PATHINFO_EXTENSION);
+        $basePath = substr($finalPath, 0, -(strlen($extension) + 1));
+
+        return sprintf('%s.tmp-%s.%s', $basePath, bin2hex(random_bytes(8)), $extension);
+    }
+
+    private function logConversionFailure(ImageContract $image, string $format, \WP_Error $error): void
+    {
+        $this->log->log(
+            $this,
+            'Cannot convert image: ' . $error->get_error_message(),
+            'warning',
+            ['image' => $image, 'format' => $format, 'reason' => $error->get_error_code()],
+        );
+
+        $this->conversionCache->markConversionFailed($image);
     }
 
     /**
@@ -149,7 +183,7 @@ class ImageProcessor
     private function canConvertImage(ImageContract $image): true|\WP_Error
     {
         $sourceFilePath = $image->getPath();
-        $sourceFileId   = $image->getId();
+        $sourceFileId = $image->getId();
 
         // The id cannot be empty or negative
         if (empty($sourceFileId) || $sourceFileId < 0) {
@@ -196,18 +230,14 @@ class ImageProcessor
      */
     private function setPreferredImageEditorByFiletype(ImageContract $image): void
     {
-        $filePath       = $image->getPath();
+        $filePath = $image->getPath();
         $fileNameSuffix = pathinfo($filePath, PATHINFO_EXTENSION);
-        $fileTypeMime   = match (strtolower($fileNameSuffix)) {
+        $fileTypeMime = match (strtolower($fileNameSuffix)) {
             'png' => 'image/png',
-            default => false
+            default => false,
         };
 
-        $availableEditors = (
-            ($fileTypeMime === 'image/png') ?
-            ['WP_Image_Editor_GD', 'WP_Image_Editor_Imagick'] :
-            ['WP_Image_Editor_Imagick', 'WP_Image_Editor_GD']
-        );
+        $availableEditors = $fileTypeMime === 'image/png' ? ['WP_Image_Editor_GD', 'WP_Image_Editor_Imagick'] : ['WP_Image_Editor_Imagick', 'WP_Image_Editor_GD'];
 
         $this->wpService->addFilter('wp_image_editors', fn() => $availableEditors);
     }

--- a/library/ImageConvert/IntermidiateImageHandler.php
+++ b/library/ImageConvert/IntermidiateImageHandler.php
@@ -2,28 +2,28 @@
 
 namespace Municipio\ImageConvert;
 
-use Municipio\ImageConvert\Contract\ImageContract;
+use Municipio\Helper\File;
+use Municipio\HooksRegistrar\Hookable;
 use Municipio\ImageConvert\Cache\ConversionCache;
 use Municipio\ImageConvert\Cache\PageLoadCache;
-use Municipio\ImageConvert\Strategy\StrategyFactory;
-use Municipio\ImageConvert\Strategy\ConversionStrategyInterface;
-use Municipio\ImageConvert\Logging\Log;
-use WpService\Contracts\AddFilter;
-use WpService\Contracts\IsWpError;
-use WpService\Contracts\IsAdmin;
-use WpService\Contracts\DoAction;
-use WpService\Contracts\ApplyFilters;
-use Municipio\HooksRegistrar\Hookable;
 use Municipio\ImageConvert\Config\ImageConvertConfig;
-use Municipio\Helper\File;
-use WpService\Contracts\WpGetImageEditor;
-use WpService\Contracts\WpUploadDir;
-use WpService\Contracts\WpGetAttachmentMetadata;
+use Municipio\ImageConvert\Contract\ImageContract;
+use Municipio\ImageConvert\Logging\Log;
+use Municipio\ImageConvert\Strategy\ConversionStrategyInterface;
+use Municipio\ImageConvert\Strategy\StrategyFactory;
+use WpService\Contracts\AddFilter;
+use WpService\Contracts\ApplyFilters;
+use WpService\Contracts\DoAction;
+use WpService\Contracts\IsAdmin;
+use WpService\Contracts\IsWpError;
 use WpService\Contracts\WpAttachmentIs;
+use WpService\Contracts\WpCacheDelete;
 use WpService\Contracts\WpCacheGet;
 use WpService\Contracts\WpCacheSet;
-use WpService\Contracts\WpCacheDelete;
-use WP_Error;
+use WpService\Contracts\WpDeleteFile;
+use WpService\Contracts\WpGetAttachmentMetadata;
+use WpService\Contracts\WpGetImageEditor;
+use WpService\Contracts\WpUploadDir;
 
 class IntermidiateImageHandler implements Hookable
 {
@@ -32,18 +32,18 @@ class IntermidiateImageHandler implements Hookable
     private ConversionStrategyInterface $conversionStrategy;
 
     public function __construct(
-        private AddFilter&isWpError&WpGetImageEditor&WpUploadDir&WpGetAttachmentMetadata&IsAdmin&WpAttachmentIs&WpCacheGet&WpCacheSet&WpCacheDelete&DoAction&ApplyFilters $wpService,
+        private AddFilter&isWpError&WpGetImageEditor&WpUploadDir&WpGetAttachmentMetadata&IsAdmin&WpAttachmentIs&WpCacheGet&WpCacheSet&WpCacheDelete&DoAction&ApplyFilters&WpDeleteFile $wpService,
         private ImageConvertConfig $config,
-        private Log $log
+        private Log $log,
     ) {
         $this->conversionCache = new ConversionCache($wpService, $config);
-        $this->pageLoadCache   = new PageLoadCache($wpService, $config);
+        $this->pageLoadCache = new PageLoadCache($wpService, $config);
 
-        $strategyFactory          = new StrategyFactory(
+        $strategyFactory = new StrategyFactory(
             $wpService,
             $config,
             $this->conversionCache,
-            $this->log
+            $this->log,
         );
         $this->conversionStrategy = $strategyFactory->createStrategy();
     }
@@ -61,7 +61,7 @@ class IntermidiateImageHandler implements Hookable
             $this->config->createFilterKey('imageDownsize'),
             [$this, 'createIntermidiateImage'],
             $this->config->internalFilterPriority()->intermidiateImageConvert,
-            1
+            1,
         );
 
         // Clear conversion cache when attachments are deleted or updated
@@ -89,7 +89,7 @@ class IntermidiateImageHandler implements Hookable
                 $this,
                 'Recent conversion failure detected, skipping conversion.',
                 'warning',
-                ['image' => $image, 'format' => $format, 'reason' => 'recent_failure']
+                ['image' => $image, 'format' => $format, 'reason' => 'recent_failure'],
             );
 
             return $image;
@@ -102,21 +102,14 @@ class IntermidiateImageHandler implements Hookable
                 $this,
                 'Could not determine intermediate image location, skipping conversion.',
                 'warning',
-                ['image' => $image, 'format' => $format, 'reason' => 'no_intermediate_location']
+                ['image' => $image, 'format' => $format, 'reason' => 'no_intermediate_location'],
             );
 
             return $image;
         }
 
-        //If already processed in this request, return the intermediate image, it will exist anyway
-        if ($this->pageLoadCache->hasBeenProcessedInCurrentRequest($image)) {
-            $image->setUrl($intermediateLocation['url']);
-            $image->setPath($intermediateLocation['path']);
-            return $image;
-        }
-
-        // Check if the intermediate image already exists, if so return it
-        if (file_exists($intermediateLocation['path'])) {
+        // Only reuse complete images with the expected type and dimensions.
+        if ($this->isValidIntermediateImage($image, $intermediateLocation['path'])) {
             $image->setUrl($intermediateLocation['url']);
             $image->setPath($intermediateLocation['path']);
 
@@ -129,11 +122,50 @@ class IntermidiateImageHandler implements Hookable
             return $image;
         }
 
+        // A failed editor can leave an empty or malformed file behind. Remove it
+        // before retrying so it can never be mistaken for a successful result.
+        if (file_exists($intermediateLocation['path'])) {
+            $this->wpService->wpDeleteFile($intermediateLocation['path']);
+
+            if (file_exists($intermediateLocation['path'])) {
+                $this->log->log(
+                    $this,
+                    'Could not remove an invalid intermediate image, skipping conversion.',
+                    'warning',
+                    ['image' => $image, 'format' => $format, 'reason' => 'invalid_intermediate_cleanup_failed'],
+                );
+                $this->conversionCache->markConversionFailed($image);
+
+                return $image;
+            }
+        }
+
+        // A failed conversion in this request must fall back to the source image
+        // instead of exposing the missing or invalid intermediate URL.
+        if ($this->pageLoadCache->hasBeenProcessedInCurrentRequest($image)) {
+            return $image;
+        }
+
         // Mark as processed in current request to prevent duplicate processing
         $this->pageLoadCache->markProcessedInCurrentRequest($image);
 
         // Use the selected conversion strategy
         return $this->conversionStrategy->process($image);
+    }
+
+    private function isValidIntermediateImage(ImageContract $image, string $path): bool
+    {
+        $sourceSize = File::getImageSizeWithoutWarnings($image->getPath());
+        if ($sourceSize === false) {
+            return false;
+        }
+
+        return File::isValidImage(
+            $path,
+            File::getImageMimeTypeForPath($path),
+            min($image->getWidth(), $sourceSize[0]),
+            min($image->getHeight(), $sourceSize[1]),
+        );
     }
 
     /**


### PR DESCRIPTION
Image conversion currently treats any existing intermediate path as a successful result. Failed image editors can therefore leave empty or malformed files that are served indefinitely, and the request cache can return the same invalid URL.

Validate type and dimensions before reuse, write conversions to a temporary sibling file before an atomic rename, remove invalid leftovers, and preserve the source-image fallback when conversion fails. Relates to #1504.