### PR TITLE
Allow filtering content area visibility

### DIFF
--- a/views/v3/page-centered.blade.php
+++ b/views/v3/page-centered.blade.php
@@ -10,7 +10,11 @@
     @includeIf('partials.loop')
     @show
 
-    @includeIf('partials.sidebar', ['id' => 'content-area', 'classes' => ['o-grid']])
+    @includeWhen(
+        apply_filters('Municipio/views/page-centered/content-area/show', true),
+        'partials.sidebar',
+        ['id' => 'content-area', 'classes' => ['o-grid']]
+    )
 
     @includeWhen($quicklinksPlacement === 'below_content', 'partials.navigation.fixed')
 

--- a/views/v3/templates/single.blade.php
+++ b/views/v3/templates/single.blade.php
@@ -53,7 +53,11 @@
         @includeIf('partials.loop')
     @show
 
-    @includeIf('partials.sidebar', ['id' => 'content-area', 'classes' => ['o-grid']])
+    @includeWhen(
+        apply_filters('Municipio/views/single/content-area/show', true),
+        'partials.sidebar',
+        ['id' => 'content-area', 'classes' => ['o-grid']]
+    )
 
     @includeWhen($quicklinksPlacement === 'below_content', 'partials.navigation.fixed')
 


### PR DESCRIPTION
The single and centered-page templates always render the content area outside the article, which prevents extensions from relocating it without duplicating the same sidebar output.

This change adds opt-out filters around the two existing inclusions. Both filters default to `true`, so current rendering remains unchanged unless an extension explicitly handles the content area elsewhere.
