### PR TITLE
Document contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing to Municipio
+
+Read the [project guidelines](guidelines.md) before changing code. They contain
+project-specific rules that may not be covered by automated checks.

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,10 @@ Municipio requires [ACF PRO](https://www.advancedcustomfields.com/pro/).
 ## Coding standards
 For PHP, use PSR-2 and PSR-4 where applicable.
 
+## Contributing
+Read the [contribution guide](CONTRIBUTING.md) before submitting changes. It
+links to the project's view and controller guidelines.
+
 ## Build System (Vite)
 Municipio uses Vite for modern, fast asset building. Vite provides better performance, simpler configuration, and excellent ES module support.
 


### PR DESCRIPTION
Repository-specific development rules live in `guidelines.md`, but GitHub does not surface that file as contribution guidance and the main readme does not link to it.

This adds a `CONTRIBUTING.md` pointer and links it from the readme. The existing guidelines remain the single source for the rules.
