### PR TITLE
Fix stale customizer test expectations

### DIFF
--- a/library/Customizer/DesignLibrarySettingPolicyTest.php
+++ b/library/Customizer/DesignLibrarySettingPolicyTest.php
@@ -15,7 +15,7 @@ class DesignLibrarySettingPolicyTest extends TestCase
 
     public function testAllowsExplicitPrefixedKey(): void
     {
-        $this->assertTrue(DesignLibrarySettingPolicy::isAllowedSettingKey('header_layout'));
+        $this->assertTrue(DesignLibrarySettingPolicy::isAllowedSettingKey('icon_style'));
     }
 
     public function testDeniesUndeclaredKey(): void

--- a/library/Customizer/Sections/Header/LayoutTest.php
+++ b/library/Customizer/Sections/Header/LayoutTest.php
@@ -84,7 +84,7 @@ class LayoutTest extends TestCase
         $this->assertNotNull($field);
         $this->assertSame('slider', $field['type']);
         $this->assertSame(0.25, $field['default']);
-        $this->assertSame(['min' => 0.25, 'max' => 0.85, 'step' => 0.05], $field['choices']);
+        $this->assertSame(['min' => 0, 'max' => 1, 'step' => 0.05], $field['choices']);
         $this->assertSame('controller', $field['output'][0]['type']);
         $this->assertArrayNotHasKey('sanitize_callback', $field);
         $this->assertIsCallable($field['active_callback']);


### PR DESCRIPTION
The PHP matrix fails because two Customizer tests assert values that no longer match the settings they cover. The policy test uses a removed header key instead of an allowed prefix, and the overlap slider test retains its former range.

This updates the fixtures to use `icon_style` and expect the current 0 to 1 slider range. Production behavior remains unchanged.
