### PR TITLE
🐛 Bug(chat): buffer SSE events

### DIFF
--- a/library/Chat/Api/ChatEndpoint.php
+++ b/library/Chat/Api/ChatEndpoint.php
@@ -178,6 +178,7 @@ class ChatEndpoint extends RestApiEndpoint
         }
 
         $ch = curl_init($chatUrl);
+        $accum = '';
 
         try {
             curl_setopt_array($ch, [
@@ -188,11 +189,20 @@ class ChatEndpoint extends RestApiEndpoint
                 ],
                 CURLOPT_POSTFIELDS => json_encode($body),
                 CURLOPT_RETURNTRANSFER => false,
-                CURLOPT_WRITEFUNCTION => static function ($ch, $data) {
-                    echo $data . "\n\n";
-                    ob_flush();
-                    flush();
-                    return \strlen($data);
+                CURLOPT_WRITEFUNCTION => static function ($ch, $data) use (&$accum) {
+                    $accum .= $data;
+                    $accum = str_replace(["\r\n", "\r"], "\n", $accum);
+
+                    while (($eventEnd = strpos($accum, "\n\n")) !== false) {
+                        $event = substr($accum, 0, $eventEnd);
+                        $accum = substr($accum, $eventEnd + 2);
+
+                        echo $event . "\n\n";
+                        ob_flush();
+                        flush();
+                    }
+
+                    return strlen($data);
                 },
             ]);
 


### PR DESCRIPTION
Buffer SSE events to avoid sending partial events downstream (causes problems if partial payload is a JSON block for example). Also handles if multiple events are part of the same chunk.