### PR TITLE
feat: performance tuning 

### DIFF
--- a/library/Controller/BaseController.php
+++ b/library/Controller/BaseController.php
@@ -422,16 +422,21 @@ class BaseController
         add_filter(
             'ComponentLibrary/Component/Lang',
             function ($obj) {
-                $lang = [
-                    'visit' => __('Visit', 'municipio'),
-                    'email' => __('Email', 'municipio'),
-                    'call' => __('Call', 'municipio'),
-                    'address' => __('Address', 'municipio'),
-                    'visitingAddress' => __('Visiting address', 'municipio'),
-                    'goToHomepage' => __('Go to homepage', 'municipio'),
-                ];
+                static $langByLocale = [];
+                $locale = get_locale();
 
-                return (object) array_merge((array) $obj, $lang);
+                if (!isset($langByLocale[$locale])) {
+                    $langByLocale[$locale] = [
+                        'visit' => __('Visit', 'municipio'),
+                        'email' => __('Email', 'municipio'),
+                        'call' => __('Call', 'municipio'),
+                        'address' => __('Address', 'municipio'),
+                        'visitingAddress' => __('Visiting address', 'municipio'),
+                        'goToHomepage' => __('Go to homepage', 'municipio'),
+                    ];
+                }
+
+                return (object) array_merge((array) $obj, $langByLocale[$locale]);
             },
             10,
             1,

--- a/library/Customizer/Applicators/AbstractApplicator.php
+++ b/library/Customizer/Applicators/AbstractApplicator.php
@@ -31,6 +31,10 @@ abstract class AbstractApplicator
      */
     private function getRegisteredFields(): array
     {
+        if (isset($this->runtimeCache['registeredFields'])) {
+            return $this->runtimeCache['registeredFields'];
+        }
+
         $fields = [];
 
         foreach (PanelsRegistry::getInstance()->getRegisteredFields() as $field) {
@@ -41,7 +45,7 @@ abstract class AbstractApplicator
             $fields[$field['settings']] = $field;
         }
 
-        return $fields;
+        return $this->runtimeCache['registeredFields'] = $fields;
     }
 
     /**

--- a/library/Customizer/Applicators/NativeFieldApplicatorTest.php
+++ b/library/Customizer/Applicators/NativeFieldApplicatorTest.php
@@ -91,6 +91,24 @@ namespace Municipio\Customizer\Applicators {
             $this->assertSame(NativeField::FIELD_DRIVER, $fields['native_applicator_field'][NativeField::FIELD_DRIVER_KEY]);
         }
 
+        #[TestDox('registered fields are indexed once per applicator instance')]
+        public function testRegisteredFieldsAreIndexedOncePerApplicatorInstance(): void
+        {
+            PanelsRegistry::getInstance()->addRegisteredField([
+                'settings' => 'first_field',
+            ]);
+
+            $applicator = new ExposedFieldsApplicator();
+            $this->assertArrayHasKey('first_field', $applicator->exposedFields());
+
+            PanelsRegistry::getInstance()->addRegisteredField([
+                'settings' => 'second_field',
+            ]);
+
+            $this->assertArrayNotHasKey('second_field', $applicator->exposedFields());
+            $this->assertArrayHasKey('second_field', (new ExposedFieldsApplicator())->exposedFields());
+        }
+
         #[TestDox('getFieldValue reads native field values from theme mods with defaults')]
         public function testGetFieldValueReadsNativeFieldValuesFromThemeModsWithDefaults(): void
         {

--- a/library/Customizer/Applicators/Types/ApplicatorRuntimeCacheTest.php
+++ b/library/Customizer/Applicators/Types/ApplicatorRuntimeCacheTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Municipio\Customizer\Applicators\Types;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use WpService\Implementations\FakeWpService;
+
+class ApplicatorRuntimeCacheTest extends TestCase
+{
+    #[TestDox('component rule matches are reused without caching component-specific data')]
+    public function testComponentRuleMatchesAreReusedWithoutCachingComponentData(): void
+    {
+        $applicator = new Component(new FakeWpService(['addFilter' => true]));
+        $applicator->applyData([
+            [
+                'contexts' => [
+                    ['operator' => '==', 'context' => 'component.button'],
+                ],
+                'data' => [
+                    'classList' => 'from-customizer',
+                    'size' => 'medium',
+                ],
+            ],
+        ]);
+
+        $first = $applicator->applyDataFilterFunction([
+            'context' => ['component.button'],
+            'classList' => ['first-instance'],
+            'label' => 'First',
+        ]);
+        $second = $applicator->applyDataFilterFunction([
+            'context' => ['component.button'],
+            'classList' => ['second-instance'],
+            'label' => 'Second',
+        ]);
+
+        $this->assertSame(['first-instance', 'from-customizer'], $first['classList']);
+        $this->assertSame('First', $first['label']);
+        $this->assertSame(['second-instance', 'from-customizer'], $second['classList']);
+        $this->assertSame('Second', $second['label']);
+        $this->assertSame('medium', $second['size']);
+        $this->assertCount(1, $this->getPrivateArray($applicator, 'matchingFiltersCache'));
+    }
+
+    #[TestDox('component rule cache is cleared when applicator data changes')]
+    public function testComponentRuleCacheIsClearedWhenApplicatorDataChanges(): void
+    {
+        $applicator = new Component(new FakeWpService(['addFilter' => true]));
+        $applicator->applyData([$this->componentRule('old')]);
+        $applicator->applyDataFilterFunction(['context' => ['component.button']]);
+
+        $applicator->applyData([$this->componentRule('new')]);
+        $result = $applicator->applyDataFilterFunction(['context' => ['component.button']]);
+
+        $this->assertSame('new', $result['value']);
+        $this->assertCount(1, $this->getPrivateArray($applicator, 'matchingFiltersCache'));
+    }
+
+    #[TestDox('modifier results are reused by context and cleared when applicator data changes')]
+    public function testModifierResultsAreReusedAndInvalidated(): void
+    {
+        $applicator = new Modifier(new FakeWpService(['addFilter' => true]));
+        $applicator->applyData([$this->modifierRule('old')]);
+
+        $this->assertSame(['old'], $applicator->applyDataFilterFunction([], ['component.button']));
+        $this->assertSame(['old'], $applicator->applyDataFilterFunction([], ['component.button']));
+        $this->assertCount(1, $this->getPrivateArray($applicator, 'resolvedModifiersCache'));
+
+        $applicator->applyData([$this->modifierRule('new')]);
+
+        $this->assertSame(['new'], $applicator->applyDataFilterFunction([], ['component.button']));
+        $this->assertCount(1, $this->getPrivateArray($applicator, 'resolvedModifiersCache'));
+    }
+
+    private function componentRule(string $value): array
+    {
+        return [
+            'contexts' => [
+                ['operator' => '==', 'context' => 'component.button'],
+            ],
+            'data' => ['value' => $value],
+        ];
+    }
+
+    private function modifierRule(string $value): array
+    {
+        return [
+            'contexts' => [
+                ['operator' => '==', 'context' => 'component.button'],
+            ],
+            'value' => $value,
+        ];
+    }
+
+    private function getPrivateArray(object $object, string $property): array
+    {
+        $reflection = new \ReflectionProperty($object, $property);
+        $reflection->setAccessible(true);
+
+        return $reflection->getValue($object);
+    }
+}

--- a/library/Customizer/Applicators/Types/Component.php
+++ b/library/Customizer/Applicators/Types/Component.php
@@ -10,6 +10,7 @@ use WpService\WpService;
 class Component extends AbstractApplicator implements ApplicatorInterface
 {
     private array $cachedData = [];
+    private array $matchingFiltersCache = [];
 
     public function __construct(
         private WpService $wpService,
@@ -23,6 +24,7 @@ class Component extends AbstractApplicator implements ApplicatorInterface
     public function applyData(array|object $data)
     {
         $this->cachedData = $data;
+        $this->matchingFiltersCache = [];
         $this->wpService->addFilter('ComponentLibrary/Component/Data', [$this, 'applyDataFilterFunction'], 10, 1);
     }
 
@@ -35,10 +37,38 @@ class Component extends AbstractApplicator implements ApplicatorInterface
      */
     public function applyDataFilterFunction($data)
     {
-        $storedComponentData = $this->cachedData;
         $contexts = isset($data['context']) ? (array) $data['context'] : [];
 
-        foreach ($storedComponentData as $filter) {
+        foreach ($this->getMatchingFilters($contexts) as $filter) {
+            if (isset($filter['data']['classList']) && is_string($filter['data']['classList'])) {
+                // Ensure classList is an array and handle before merging it with existing classList in data.
+                $data['classList'] = array_merge($data['classList'] ?? [], [$filter['data']['classList']]);
+                unset($filter['data']['classList']);
+            }
+
+            $data = array_replace_recursive($data, $filter['data']);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get the customizer filters matching a component context combination.
+     *
+     * @param array $contexts Component contexts.
+     * @return array Matching filters.
+     */
+    private function getMatchingFilters(array $contexts): array
+    {
+        $cacheKey = serialize($contexts);
+
+        if (isset($this->matchingFiltersCache[$cacheKey])) {
+            return $this->matchingFiltersCache[$cacheKey];
+        }
+
+        $matchingFilters = [];
+
+        foreach ($this->cachedData as $filter) {
             $passFilterRules = false;
 
             $andOperators = array_filter($filter['contexts'], function ($context) {
@@ -62,17 +92,11 @@ class Component extends AbstractApplicator implements ApplicatorInterface
             }
 
             if ($passFilterRules) {
-                if (isset($filter['data']['classList']) && is_string($filter['data']['classList'])) {
-                    // Ensure classList is an array and handle before merging it with existing classList in data.
-                    $data['classList'] = array_merge($data['classList'] ?? [], [$filter['data']['classList']]);
-                    unset($filter['data']['classList']);
-                }
-
-                $data = array_replace_recursive($data, $filter['data']);
+                $matchingFilters[] = $filter;
             }
         }
 
-        return $data;
+        return $this->matchingFiltersCache[$cacheKey] = $matchingFilters;
     }
 
     /**

--- a/library/Customizer/Applicators/Types/Modifier.php
+++ b/library/Customizer/Applicators/Types/Modifier.php
@@ -9,6 +9,7 @@ use WpService\WpService;
 class Modifier extends AbstractApplicator implements ApplicatorInterface
 {
     private array $cachedData = [];
+    private array $resolvedModifiersCache = [];
 
     public function __construct(
         private WpService $wpService,
@@ -22,6 +23,7 @@ class Modifier extends AbstractApplicator implements ApplicatorInterface
     public function applyData(array|object $data)
     {
         $this->cachedData = $data;
+        $this->resolvedModifiersCache = [];
         $this->wpService->addFilter('ComponentLibrary/Component/Modifier', [$this, 'applyDataFilterFunction'], 10, 2);
     }
 
@@ -36,6 +38,12 @@ class Modifier extends AbstractApplicator implements ApplicatorInterface
     public function applyDataFilterFunction(array|string $modifiers, array|string $contexts): array|string
     {
         $contexts = is_array($contexts) ? $contexts : [$contexts];
+        $cacheKey = serialize($contexts);
+
+        if (isset($this->resolvedModifiersCache[$cacheKey])) {
+            return $this->resolvedModifiersCache[$cacheKey];
+        }
+
         $modifiers = is_array($this->cachedData) ? $this->cachedData : [$this->cachedData];
 
         $returnModifiers = [];
@@ -68,7 +76,7 @@ class Modifier extends AbstractApplicator implements ApplicatorInterface
             }
         }
 
-        return $returnModifiers;
+        return $this->resolvedModifiersCache[$cacheKey] = $returnModifiers;
     }
 
     /**

--- a/library/Helper/Post.php
+++ b/library/Helper/Post.php
@@ -275,7 +275,10 @@ class Post
                 (int) $thumbnailId,
                 [1920, false],
                 new ImageResolver(),
-                new ImageFocusResolver(['id' => $thumbnailId])
+                new ImageFocusResolver([
+                    'id' => $thumbnailId,
+                    'ratio' => [1920, false]
+                ])
             );
         }
 

--- a/library/Integrations/Component/ImageFocusResolver.php
+++ b/library/Integrations/Component/ImageFocusResolver.php
@@ -6,6 +6,8 @@ use ComponentLibrary\Integrations\Image\ImageFocusResolverInterface;
 
 class ImageFocusResolver implements ImageFocusResolverInterface
 {
+    private static array $runtimeCache = [];
+
   /**
    * Constructor
    *
@@ -33,9 +35,59 @@ class ImageFocusResolver implements ImageFocusResolverInterface
         }
 
         if (!empty($data['id']) && $focusPoint['left'] === 50 && $focusPoint['top'] === 50) {
+            $cacheKey = $this->getCacheKey($data);
+
+            if (array_key_exists($cacheKey, self::$runtimeCache)) {
+                return self::$runtimeCache[$cacheKey];
+            }
+
             $focusPoint = apply_filters('attachment_focus_point', $focusPoint, $data['id']);
+            self::$runtimeCache[$cacheKey] = $focusPoint;
         }
 
         return $focusPoint;
+    }
+
+    /**
+     * Cache focus points for the same attachment and aspect ratio during a request.
+     */
+    private function getCacheKey(array $data): string
+    {
+        $blogId = function_exists('get_current_blog_id') ? get_current_blog_id() : 0;
+
+        return implode(':', [
+            $blogId,
+            (int) $data['id'],
+            $this->normalizeRatio($data['ratio'] ?? null)
+        ]);
+    }
+
+    private function normalizeRatio($ratio): string
+    {
+        if (
+            !is_array($ratio) ||
+            !isset($ratio[0], $ratio[1]) ||
+            !is_numeric($ratio[0]) ||
+            !is_numeric($ratio[1]) ||
+            (int) $ratio[0] <= 0 ||
+            (int) $ratio[1] <= 0
+        ) {
+            return 'intrinsic';
+        }
+
+        $width = (int) round($ratio[0]);
+        $height = (int) round($ratio[1]);
+        $divisor = $this->greatestCommonDivisor($width, $height);
+
+        return ($width / $divisor) . ':' . ($height / $divisor);
+    }
+
+    private function greatestCommonDivisor(int $first, int $second): int
+    {
+        while ($second !== 0) {
+            [$first, $second] = [$second, $first % $second];
+        }
+
+        return $first;
     }
 }

--- a/library/Integrations/Component/ImageFocusResolverTest.php
+++ b/library/Integrations/Component/ImageFocusResolverTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Municipio\Integrations\Component;
+
+use PHPUnit\Framework\TestCase;
+
+function apply_filters($hookName, $focusPoint, $imageId)
+{
+    $GLOBALS['image_focus_resolver_filter_calls']++;
+
+    return [
+        'left' => $imageId,
+        'top' => $imageId,
+    ];
+}
+
+function get_current_blog_id()
+{
+    return $GLOBALS['image_focus_resolver_blog_id'];
+}
+
+class ImageFocusResolverTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['image_focus_resolver_filter_calls'] = 0;
+        $GLOBALS['image_focus_resolver_blog_id'] = 1;
+    }
+
+    public function testCachesFocusPointForEquivalentRatios(): void
+    {
+        $first = new ImageFocusResolver(['id' => 101, 'ratio' => [800, 600]]);
+        $second = new ImageFocusResolver(['id' => 101, 'ratio' => [400, 300]]);
+
+        $this->assertSame($first->getFocusPoint(), $second->getFocusPoint());
+        $this->assertSame(1, $GLOBALS['image_focus_resolver_filter_calls']);
+    }
+
+    public function testDoesNotShareFocusPointBetweenDifferentRatios(): void
+    {
+        $first = new ImageFocusResolver(['id' => 102, 'ratio' => [800, 600]]);
+        $second = new ImageFocusResolver(['id' => 102, 'ratio' => [800, 450]]);
+
+        $first->getFocusPoint();
+        $second->getFocusPoint();
+
+        $this->assertSame(2, $GLOBALS['image_focus_resolver_filter_calls']);
+    }
+
+    public function testDoesNotShareFocusPointBetweenBlogs(): void
+    {
+        $first = new ImageFocusResolver(['id' => 103, 'ratio' => [800, 600]]);
+        $first->getFocusPoint();
+
+        $GLOBALS['image_focus_resolver_blog_id'] = 2;
+        $second = new ImageFocusResolver(['id' => 103, 'ratio' => [400, 300]]);
+        $second->getFocusPoint();
+
+        $this->assertSame(2, $GLOBALS['image_focus_resolver_filter_calls']);
+    }
+}

--- a/library/MarkupProcessor/Processors/TidyProcessor.php
+++ b/library/MarkupProcessor/Processors/TidyProcessor.php
@@ -18,7 +18,11 @@ class TidyProcessor implements MarkupProcessorInterface
             return $markup;
         }
 
-        [$markup, $templates] = $this->extractOuterTemplates($markup) ?? ['', []];
+        $templates = [];
+        if (stripos($markup, '<template') !== false) {
+            [$markup, $templates] = $this->extractOuterTemplates($markup);
+        }
+
         $tidy = new \tidy();
         $tidy->parseString(
             $markup,
@@ -38,7 +42,11 @@ class TidyProcessor implements MarkupProcessorInterface
         // Clean and repair the document
         $tidy->cleanRepair();
         $markup = (string) $tidy;
-        $markup = str_replace(array_keys($templates), array_values($templates), $markup);
+
+        if ($templates !== []) {
+            $markup = str_replace(array_keys($templates), array_values($templates), $markup);
+        }
+
         return $markup;
     }
 

--- a/library/MarkupProcessor/Processors/TidyProcessorTest.php
+++ b/library/MarkupProcessor/Processors/TidyProcessorTest.php
@@ -24,6 +24,22 @@ class TidyProcessorTest extends TestCase
         $this->assertNotSame($input, $processor->process($input));
     }
 
+    #[TestDox('repairs markup without template elements')]
+    public function testProcessWithoutTemplateTags(): void
+    {
+        if (!extension_loaded('tidy')) {
+            $this->assertTrue(true, 'Tidy extension is not available, skipping test.');
+            return;
+        }
+
+        $processor = new TidyProcessor();
+        $input = '<!DOCTYPE html><html><body><main><p>Test</main></body></html>';
+        $processed = $processor->process($input);
+
+        $this->assertStringContainsString('</p>', $processed);
+        $this->assertStringContainsString('</main>', $processed);
+    }
+
     #[TestDox('returns original markup if tidy extension is not available')]
     public function testProcessWithoutTidy(): void
     {

--- a/library/MirroredPost/PostObject/MirroredPostObject.php
+++ b/library/MirroredPost/PostObject/MirroredPostObject.php
@@ -89,7 +89,10 @@ class MirroredPostObject extends AbstractPostObjectDecorator implements PostObje
                 new BlogSwitchedImageResolver($this->getBlogId(), new ImageResolver(), $this->wpService),
                 new BlogSwitchedImageFocusResolver(
                     $this->getBlogId(),
-                    new ImageFocusResolver(['id' => $imageId]),
+                    new ImageFocusResolver([
+                        'id' => $imageId,
+                        'ratio' => [$width, $height],
+                    ]),
                     $this->wpService,
                 ),
             )

--- a/library/PostObject/PostObject.php
+++ b/library/PostObject/PostObject.php
@@ -190,7 +190,10 @@ class PostObject implements PostObjectInterface
             (int) $imageId,
             [$width, $height],
             new ImageResolver(),
-            new ImageFocusResolver(['id' => $imageId])
+            new ImageFocusResolver([
+                'id' => $imageId,
+                'ratio' => [$width, $height]
+            ])
         ) : null;
     }
 }


### PR DESCRIPTION
This pull request introduces runtime caching and cache invalidation for several components, improving performance and correctness when processing data and images with context-specific logic. It also adds comprehensive tests for the new caching behavior and refines the handling of template elements in markup processing.

### Runtime Caching and Invalidation

* Added runtime caches to `Component` and `Modifier` applicators to avoid redundant rule matching and modifier resolution; caches are invalidated when applicator data changes. [[1]](diffhunk://#diff-398bb2646e2321f6280d2512b45cc0554a0051eb52a879dd2504380f9d929fefR13) [[2]](diffhunk://#diff-398bb2646e2321f6280d2512b45cc0554a0051eb52a879dd2504380f9d929fefR27) [[3]](diffhunk://#diff-398bb2646e2321f6280d2512b45cc0554a0051eb52a879dd2504380f9d929fefL38-R71) [[4]](diffhunk://#diff-398bb2646e2321f6280d2512b45cc0554a0051eb52a879dd2504380f9d929fefL65-R99) [[5]](diffhunk://#diff-bacf8947771ce0bd3cec1d7e9474cc49baf7b6b60dcb3ced2ab49278a9853b41R12) [[6]](diffhunk://#diff-bacf8947771ce0bd3cec1d7e9474cc49baf7b6b60dcb3ced2ab49278a9853b41R26) [[7]](diffhunk://#diff-bacf8947771ce0bd3cec1d7e9474cc49baf7b6b60dcb3ced2ab49278a9853b41R41-R46) [[8]](diffhunk://#diff-bacf8947771ce0bd3cec1d7e9474cc49baf7b6b60dcb3ced2ab49278a9853b41L71-R79)
* Introduced a runtime cache in `ImageFocusResolver` to reuse focus points for the same image and aspect ratio (normalized across equivalent ratios and blogs), reducing repeated filter calls. [[1]](diffhunk://#diff-54191a8311451fc26196d6b2314caae0785c82561d39262fb10f370db9125789R9-R10) [[2]](diffhunk://#diff-54191a8311451fc26196d6b2314caae0785c82561d39262fb10f370db9125789R38-R92)

### Bug Fixes and Improvements

* Fixed `TidyProcessor` to only extract templates when present, preventing errors with markup lacking `<template>` tags, and restored templates after processing only if any were extracted. [[1]](diffhunk://#diff-8720f33b9c841c30b252003b49d93e9541dd9825e4b51f2b1d2ee6dcb9dd9827L21-R25) [[2]](diffhunk://#diff-8720f33b9c841c30b252003b49d93e9541dd9825e4b51f2b1d2ee6dcb9dd9827R45-R49)

### Testing

* Added `ApplicatorRuntimeCacheTest` to verify caching and invalidation for component and modifier applicators.
* Added `ImageFocusResolverTest` to confirm correct caching by ratio and blog, and that filter calls are minimized.
* Added and updated tests for `TidyProcessor` to cover markup with and without template tags.

### Other Enhancements

* Improved field registration in `AbstractApplicator` by caching registered fields per applicator instance, with tests to verify correct cache isolation. [[1]](diffhunk://#diff-5848fa3f06e6a9e62c3e437bf0b187b3a9c5102627eb6540fff2ee6ef1461bdeR34-R37) [[2]](diffhunk://#diff-5848fa3f06e6a9e62c3e437bf0b187b3a9c5102627eb6540fff2ee6ef1461bdeL44-R48) [[3]](diffhunk://#diff-1805e3df3e8e0a2abe9c939148c4e8ddcdf78a51f80d99d7ae81ba638430a023R94-R111)
* Ensured `ImageFocusResolver` receives aspect ratio information in all code paths where images are resolved, improving cache key accuracy. [[1]](diffhunk://#diff-c15538f9f8643ebb3f8a5b06afcc17a04b4bb80bcb8b8b5c6c4b2581332a643dL278-R281) [[2]](diffhunk://#diff-c80063fdccba8cdce6f985b382da3a4becec87d383cb9786554ff981edcac92bL92-R95) [[3]](diffhunk://#diff-e17074f70afbe7cfd051d1673352a66821c80885f4d17b76b10cc2727844068bL193-R196)

### Localization

* Optimized language array generation in `BaseController` by caching per locale, reducing redundant translation lookups.