### PR TITLE
feat: check if TOC is enabled before parsing page

### DIFF
--- a/library/Toc/Utils/TocUtils.php
+++ b/library/Toc/Utils/TocUtils.php
@@ -48,15 +48,15 @@ class TocUtils implements TocUtilsInterface
             return $runtimeCache[$postId] = false;
         }
 
-        // Check if post has content
-        $content = $postObject->getContent();
-        if (empty($content)) {
-            return $runtimeCache[$postId] = false;
-        }
-
         //Check if get field 'toc' is set to true
         $isEnabledOnPost = $this->acfService->getField('post_table_of_contents', $postObject->getId(), false) ?? false;
         if (empty($isEnabledOnPost)) {
+            return $runtimeCache[$postId] = false;
+        }
+
+        // Check if post has content
+        $content = $postObject->getContent();
+        if (empty($content)) {
             return $runtimeCache[$postId] = false;
         }
 

--- a/library/Toc/Utils/TocUtilsTest.php
+++ b/library/Toc/Utils/TocUtilsTest.php
@@ -33,11 +33,15 @@ class TocUtilsTest extends TestCase
     #[TestDox('shouldEnableToc returns false when content is empty')]
     public function testShouldEnableTocReturnsFalseWhenContentIsEmpty(): void
     {
-        $wpService  = new FakeWpService(['isSingular' => true]);
+        $postId     = 101;
+        $wpService  = new FakeWpService(['isSingular' => true, 'getQueriedObjectId' => $postId]);
         $postObject = $this->createMock(PostObjectInterface::class);
+        $postObject->method('getId')->willReturn($postId);
         $postObject->method('getContent')->willReturn('');
 
-        $tocUtils = new TocUtils($wpService, new \AcfService\Implementations\FakeAcfService());
+        $tocUtils = new TocUtils($wpService, new \AcfService\Implementations\FakeAcfService(
+            ['getField' => true]
+        ));
         $result   = $tocUtils->shouldEnableToc($postObject);
 
         $this->assertFalse($result);
@@ -46,14 +50,34 @@ class TocUtilsTest extends TestCase
     #[TestDox('shouldEnableToc returns false when content has no headings')]
     public function testShouldEnableTocReturnsFalseWhenContentHasNoHeadings(): void
     {
-        $wpService  = new FakeWpService(['isSingular' => true]);
+        $postId     = 102;
+        $wpService  = new FakeWpService(['isSingular' => true, 'getQueriedObjectId' => $postId]);
         $postObject = $this->createMock(PostObjectInterface::class);
+        $postObject->method('getId')->willReturn($postId);
         $postObject->method('getContent')->willReturn('<p>Just some paragraph text with no headings.</p>');
 
-        $tocUtils = new TocUtils($wpService, new \AcfService\Implementations\FakeAcfService());
+        $tocUtils = new TocUtils($wpService, new \AcfService\Implementations\FakeAcfService(
+            ['getField' => true]
+        ));
         $result   = $tocUtils->shouldEnableToc($postObject);
 
         $this->assertFalse($result);
+    }
+
+    #[TestDox('shouldEnableToc does not render content when disabled on the post')]
+    public function testShouldEnableTocDoesNotRenderContentWhenDisabledOnPost(): void
+    {
+        $postId     = 103;
+        $wpService  = new FakeWpService(['isSingular' => true, 'getQueriedObjectId' => $postId]);
+        $postObject = $this->createMock(PostObjectInterface::class);
+        $postObject->method('getId')->willReturn($postId);
+        $postObject->expects($this->never())->method('getContent');
+
+        $tocUtils = new TocUtils($wpService, new \AcfService\Implementations\FakeAcfService(
+            ['getField' => false]
+        ));
+
+        $this->assertFalse($tocUtils->shouldEnableToc($postObject));
     }
 
     #[TestDox('shouldEnableToc returns true when content has minimum reqired headings')]


### PR DESCRIPTION
This pull request refines the logic in `TocUtils::shouldEnableToc` to ensure the 'table of contents' feature only checks post content after confirming it is enabled on the post, and adds more comprehensive unit tests to verify this behavior.

### Logic improvements

* Reordered checks in `shouldEnableToc` so that the 'toc' field is checked before post content is accessed, preventing unnecessary content retrieval when the feature is disabled.

### Unit test enhancements

* Updated existing tests to provide post IDs and mock ACF field responses, ensuring the tests accurately reflect the production code's logic. [[1]](diffhunk://#diff-0356cd0cb7cad598bc26ef146233807f0fe739880f741fef66fe16381bca6899L36-R44) [[2]](diffhunk://#diff-0356cd0cb7cad598bc26ef146233807f0fe739880f741fef66fe16381bca6899L49-R82)
* Added a new test (`testShouldEnableTocDoesNotRenderContentWhenDisabledOnPost`) to verify that post content is not accessed if the 'toc' feature is disabled for the post.