### PR TITLE
fix: use footer column values correctly, default 3.

### DIFF
--- a/assets/source/js/admin/widgetsAreaHider.js
+++ b/assets/source/js/admin/widgetsAreaHider.js
@@ -21,11 +21,14 @@ document.addEventListener("DOMContentLoaded", function() {
             if (!footerAreaColumn) {
                 continue;
             }
-            const matches = footerAreaColumn.getAttribute('data-widget-area-id').match(/footer-area-column-(\d)/i);
+            const areaId = footerAreaColumn.getAttribute('data-widget-area-id');
+            const matches = areaId.match(/footer-area-column-(\d)/i);
             if (matches.length !== 2) {
                 continue;
             }
-            if (matches[1] >= municipioSidebars.footerColumns) {
+            const activeAreas = municipioSidebars.activeFooterAreas || [];
+            // Areas holding widgets must stay editable even when outside the configured column count.
+            if (matches[1] >= municipioSidebars.footerColumns && !activeAreas.includes(areaId)) {
                 node.style.display = "none";
             }
         }

--- a/library/Theme/Footer/FooterAreas.php
+++ b/library/Theme/Footer/FooterAreas.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Theme\Footer;
+
+use WpService\Contracts\GetThemeMod;
+
+/**
+ * Resolves the footer widget areas and the number of columns they are rendered in.
+ *
+ * All footer areas are always registered and rendered when they contain widgets.
+ * The design tool only decides how many columns the areas are laid out in.
+ */
+class FooterAreas
+{
+    /**
+     * Number of columns used when the design tool has no stored column count.
+     *
+     * Matches the styleguide default for --c-footer--columns-count.
+     */
+    public const DEFAULT_COLUMN_COUNT = 3;
+
+    /**
+     * Total number of registered footer widget areas.
+     */
+    public const AREA_COUNT = 6;
+
+    private const COLUMN_COUNT_TOKEN = '--c-footer--columns-count';
+
+    public function __construct(private GetThemeMod $wpService)
+    {
+    }
+
+    /**
+     * Get all registered footer widget area ids.
+     *
+     * @return array<int, string>
+     */
+    public function getAreaIds(): array
+    {
+        $areaIds = [];
+
+        for ($index = 0; $index < self::AREA_COUNT; $index++) {
+            $areaIds[] = $this->getAreaId($index);
+        }
+
+        return $areaIds;
+    }
+
+    /**
+     * Get the widget area id for a given footer area index.
+     */
+    public function getAreaId(int $index): string
+    {
+        return $index === 0 ? 'footer-area' : 'footer-area-column-' . $index;
+    }
+
+    /**
+     * Get the configured footer column count from stored design tokens.
+     */
+    public function getColumnCount(): int
+    {
+        $storedTokens = $this->wpService->getThemeMod('tokens', '');
+
+        if (!is_string($storedTokens) || trim($storedTokens) === '') {
+            return self::DEFAULT_COLUMN_COUNT;
+        }
+
+        $decodedTokens = json_decode($storedTokens, true);
+
+        if (!is_array($decodedTokens)) {
+            return self::DEFAULT_COLUMN_COUNT;
+        }
+
+        $columnCount = $decodedTokens['component']['__general__']['footer'][self::COLUMN_COUNT_TOKEN] ?? null;
+
+        if (!is_numeric($columnCount)) {
+            return self::DEFAULT_COLUMN_COUNT;
+        }
+
+        return min(self::AREA_COUNT, max(1, (int) $columnCount));
+    }
+}

--- a/library/Theme/Footer/FooterAreasTest.php
+++ b/library/Theme/Footer/FooterAreasTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Theme\Footer;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use WpService\Implementations\FakeWpService;
+
+class FooterAreasTest extends TestCase
+{
+    #[TestDox('getAreaIds returns all registered footer areas regardless of column count')]
+    public function testGetAreaIdsReturnsAllRegisteredFooterAreas(): void
+    {
+        $footerAreas = new FooterAreas($this->createWpServiceWithColumnCount('1'));
+
+        static::assertSame(
+            [
+                'footer-area',
+                'footer-area-column-1',
+                'footer-area-column-2',
+                'footer-area-column-3',
+                'footer-area-column-4',
+                'footer-area-column-5',
+            ],
+            $footerAreas->getAreaIds(),
+        );
+    }
+
+    #[TestDox('getColumnCount returns the stored design token value')]
+    public function testGetColumnCountReturnsStoredDesignTokenValue(): void
+    {
+        $footerAreas = new FooterAreas($this->createWpServiceWithColumnCount('4'));
+
+        static::assertSame(4, $footerAreas->getColumnCount());
+    }
+
+    #[TestDox('getColumnCount falls back to the styleguide default when no token is stored')]
+    public function testGetColumnCountFallsBackToDefaultWhenNoTokenIsStored(): void
+    {
+        $wpService = new FakeWpService([
+            'getThemeMod' => static fn(string $name, mixed $default = null): mixed => $default,
+        ]);
+
+        static::assertSame(FooterAreas::DEFAULT_COLUMN_COUNT, (new FooterAreas($wpService))->getColumnCount());
+    }
+
+    #[TestDox('getColumnCount falls back to the styleguide default when tokens lack a column count')]
+    public function testGetColumnCountFallsBackToDefaultWhenTokensLackColumnCount(): void
+    {
+        $wpService = new FakeWpService([
+            'getThemeMod' => static fn(string $name, mixed $default = null): mixed =>
+                $name === 'tokens' ? '{"component":{"__general__":{"footer":{}}}}' : $default,
+        ]);
+
+        static::assertSame(FooterAreas::DEFAULT_COLUMN_COUNT, (new FooterAreas($wpService))->getColumnCount());
+    }
+
+    #[TestDox('getColumnCount clamps values to the available footer areas')]
+    public function testGetColumnCountClampsValuesToAvailableFooterAreas(): void
+    {
+        $footerAreas = new FooterAreas($this->createWpServiceWithColumnCount('99'));
+
+        static::assertSame(FooterAreas::AREA_COUNT, $footerAreas->getColumnCount());
+        static::assertSame(1, (new FooterAreas($this->createWpServiceWithColumnCount('0')))->getColumnCount());
+    }
+
+    private function createWpServiceWithColumnCount(string $columnCount): FakeWpService
+    {
+        $tokens = json_encode([
+            'component' => [
+                '__general__' => [
+                    'footer' => ['--c-footer--columns-count' => $columnCount],
+                ],
+            ],
+        ]);
+
+        return new FakeWpService([
+            'getThemeMod' => static fn(string $name, mixed $default = null): mixed =>
+                $name === 'tokens' ? $tokens : $default,
+        ]);
+    }
+}

--- a/library/Theme/Sidebars.php
+++ b/library/Theme/Sidebars.php
@@ -2,6 +2,8 @@
 
 namespace Municipio\Theme;
 
+use Municipio\Theme\Footer\FooterAreas;
+
 class Sidebars
 {
     public function __construct()
@@ -38,30 +40,24 @@ class Sidebars
             'widgets-area-hide-js',
             get_template_directory_uri() . '/assets/dist/' . \Municipio\Helper\CacheBust::name('js/widgets-area-hider.js'),
         );
+        $footerAreas = $this->getFooterAreas();
+
         wp_localize_script(
             'widgets-area-hide-js',
             'municipioSidebars',
             [
-                'footerColumns' => $this->getFooterColumns(),
+                'footerColumns' => $footerAreas->getColumnCount(),
+                'activeFooterAreas' => array_values(array_filter($footerAreas->getAreaIds(), 'is_active_sidebar')),
             ],
         );
     }
 
     /**
-     * Get the configured footer column count from stored design tokens.
+     * Get the footer areas resolver.
      */
-    private function getFooterColumns(): int
+    private function getFooterAreas(): FooterAreas
     {
-        $storedTokens = get_theme_mod('tokens', '');
-
-        if (!is_string($storedTokens) || trim($storedTokens) === '') {
-            return 1;
-        }
-
-        $decodedTokens = json_decode($storedTokens, true);
-        $columnCount = $decodedTokens['component']['__general__']['footer']['--c-footer--columns-count'] ?? 1;
-
-        return max(1, (int) $columnCount);
+        return new FooterAreas(\Municipio\Helper\WpService::get());
     }
 
     public function replaceGridClasses($beforeMarkup)
@@ -110,14 +106,15 @@ class Sidebars
         ));
 
         /**
-         * Create a total of 6 footer areas for use with the column-based footer layout.
+         * Create all footer areas for use with the column-based footer layout.
          */
-        for ($i = 0; $i < 6; $i++) {
-            $suffix = $i !== 0 ? '-column-' . $i : '';
+        $footerAreas = $this->getFooterAreas();
+
+        for ($i = 0; $i < FooterAreas::AREA_COUNT; $i++) {
             register_sidebar(array(
-                'id' => 'footer-area' . $suffix,
+                'id' => $footerAreas->getAreaId($i),
                 'name' => __('Footer area', 'municipio') . ' (' . ($i + 1) . ')',
-                'description' => __('The footer area ' . $suffix, 'municipio'),
+                'description' => __('The footer area', 'municipio') . ' ' . ($i + 1),
                 'before_title' => '<h2 class="footer-title c-typography c-typography__variant--h3">',
                 'after_title' => '</h2>',
                 'before_widget' => '<div class="o-grid-12">' . $beforeWidget,


### PR DESCRIPTION
This pull request refactors how footer widget areas and columns are managed and exposed, improving maintainability and ensuring all widget areas remain editable when needed. The changes introduce a dedicated `FooterAreas` class for handling footer area logic, update the sidebar registration and visibility logic to use this new class, and add comprehensive tests.

**Footer area management improvements:**

* Introduced a new `FooterAreas` class (`library/Theme/Footer/FooterAreas.php`) that encapsulates logic for retrieving all registered footer widget area IDs and determining the configured column count, including fallback and clamping logic.
* Updated sidebar registration in `Sidebars.php` to use `FooterAreas` for consistent area IDs and column counts, replacing hard-coded values and duplicated logic.
* Updated the logic for exposing footer area configuration to JavaScript in `filterVisibleWigets` to use `FooterAreas`, and now also passes a list of active (widget-holding) footer areas for improved UI handling.

**Frontend widget area visibility:**

* Improved the JS logic in `widgetsAreaHider.js` to ensure that widget areas with widgets remain editable even if they are outside the configured column count, using the new `activeFooterAreas` data.

**Testing and reliability:**

* Added a new test suite for the `FooterAreas` class, covering area ID generation, column count retrieval, fallback, and clamping behavior.

**Code organization:**

* Added the appropriate namespace import for `FooterAreas` in `Sidebars.php`.