### PR TITLE
feat: add runtime cache to stop rendering the blocks multiple times.

### DIFF
--- a/library/Content/FilteredContentRuntimeCache.php
+++ b/library/Content/FilteredContentRuntimeCache.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Content;
+
+/**
+ * Shares filtered post content between content APIs during the current request.
+ *
+ * This compatibility cache can be removed when the legacy post object has been
+ * completely replaced and content is no longer filtered through both APIs.
+ */
+final class FilteredContentRuntimeCache
+{
+    private static array $cache = [];
+
+    /**
+     * Return an existing filtered value or create it once for this context.
+     */
+    public static function remember(
+        int $blogId,
+        int $postId,
+        string $content,
+        callable $filter
+    ): string {
+        $cacheKey = implode(':', [$blogId, $postId, md5($content)]);
+
+        if (!array_key_exists($cacheKey, self::$cache)) {
+            self::$cache[$cacheKey] = $filter($content);
+        }
+
+        return self::$cache[$cacheKey];
+    }
+
+    /**
+     * Clear request-local values. Primarily useful for isolated tests.
+     */
+    public static function clear(): void
+    {
+        self::$cache = [];
+    }
+}

--- a/library/Content/FilteredContentRuntimeCacheTest.php
+++ b/library/Content/FilteredContentRuntimeCacheTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Content;
+
+use PHPUnit\Framework\TestCase;
+
+class FilteredContentRuntimeCacheTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        FilteredContentRuntimeCache::clear();
+    }
+
+    public function testItFiltersIdenticalContentOnceInTheSameContext(): void
+    {
+        $calls  = 0;
+        $filter = static function (string $content) use (&$calls): string {
+            $calls++;
+            return $content . '-filtered-' . $calls;
+        };
+
+        $first  = FilteredContentRuntimeCache::remember(1, 10, 'content', $filter);
+        $second = FilteredContentRuntimeCache::remember(1, 10, 'content', $filter);
+
+        static::assertSame('content-filtered-1', $first);
+        static::assertSame($first, $second);
+        static::assertSame(1, $calls);
+    }
+
+    public function testItSeparatesSitesPostsAndContent(): void
+    {
+        $calls  = 0;
+        $filter = static function (string $content) use (&$calls): string {
+            $calls++;
+            return $content;
+        };
+
+        FilteredContentRuntimeCache::remember(1, 10, 'content', $filter);
+        FilteredContentRuntimeCache::remember(2, 10, 'content', $filter);
+        FilteredContentRuntimeCache::remember(1, 11, 'content', $filter);
+        FilteredContentRuntimeCache::remember(1, 10, 'other content', $filter);
+
+        static::assertSame(4, $calls);
+    }
+}

--- a/library/Controller/BaseController.php
+++ b/library/Controller/BaseController.php
@@ -17,6 +17,7 @@ use Municipio\ImagePreload\Header\HeroImagePreloadResolver;
 use Municipio\ImagePreload\Header\HeroSidebarModuleProvider;
 use Municipio\ImagePreload\Header\HeroWidgetModuleProvider;
 use Municipio\Styleguide\Customize\ResolvePostTypeScope;
+use Municipio\Theme\Footer\FooterAreas;
 use WpService\WpService;
 
 /**
@@ -824,35 +825,15 @@ class BaseController
     /**
      * Retrieves the footer settings.
      *
+     * All footer areas are always returned; the column count only decides the layout.
+     *
      * @return array An array containing the number of footer columns and footer areas.
      */
     protected function getFooterSettings()
     {
-        $footerAreas = ['footer-area'];
-        $footerColumns = $this->getFooterColumns();
+        $footerAreas = new FooterAreas($this->wpService);
 
-        for ($i = 1; $i < $footerColumns; $i++) {
-            $footerAreas[] = 'footer-area-column-' . $i;
-        }
-
-        return [$footerColumns, $footerAreas];
-    }
-
-    /**
-     * Get the configured footer column count from stored design tokens.
-     */
-    private function getFooterColumns(): int
-    {
-        $storedTokens = $this->wpService->getThemeMod('tokens', '');
-
-        if (!is_string($storedTokens) || trim($storedTokens) === '') {
-            return 1;
-        }
-
-        $decodedTokens = json_decode($storedTokens, true);
-        $columnCount = $decodedTokens['component']['__general__']['footer']['--c-footer--columns-count'] ?? 1;
-
-        return max(1, (int) $columnCount);
+        return [$footerAreas->getColumnCount(), $footerAreas->getAreaIds()];
     }
 
     /**

--- a/library/Helper/Post.php
+++ b/library/Helper/Post.php
@@ -2,6 +2,7 @@
 
 namespace Municipio\Helper;
 
+use Municipio\Content\FilteredContentRuntimeCache;
 
 use Municipio\Helper\Image;
 use WP_Post;
@@ -360,8 +361,14 @@ class Post
             $content = self::replaceBuiltinClasses(self::removeEmptyPTag($postObject->post_content));
         }
 
-        // Apply the_content (will render blocks)
-        $content = apply_filters('the_content', $content);
+        // Apply the_content (will render blocks). The PostObject API may request
+        // the same content later in this request, so share this expensive result.
+        $content = FilteredContentRuntimeCache::remember(
+            function_exists('get_current_blog_id') ? (int) get_current_blog_id() : 0,
+            isset($postObject->ID) ? (int) $postObject->ID : 0,
+            $content,
+            static fn(string $content): string => apply_filters('the_content', $content)
+        );
 
         // Build post_content_filtered
         $return = $excerpt . $content;

--- a/library/PostObject/Decorators/PostObjectWithFilteredContent.php
+++ b/library/PostObject/Decorators/PostObjectWithFilteredContent.php
@@ -2,6 +2,7 @@
 
 namespace Municipio\PostObject\Decorators;
 
+use Municipio\Content\FilteredContentRuntimeCache;
 use Municipio\PostObject\PostObjectInterface;
 use WpService\WpService;
 
@@ -92,7 +93,12 @@ class PostObjectWithFilteredContent extends AbstractPostObjectDecorator implemen
 
         // Apply WordPress filters
         $excerpt = $this->wpService->applyFilters('the_excerpt', $excerpt);
-        $content = $this->wpService->applyFilters('the_content', $content);
+        $content = FilteredContentRuntimeCache::remember(
+            $this->wpService->getCurrentBlogId(),
+            $this->postObject->getId(),
+            $content,
+            fn(string $content): string => $this->wpService->applyFilters('the_content', $content)
+        );
 
         // Build filtered content
         $return = $excerpt . $content;

--- a/library/PostObject/Decorators/PostObjectWithFilteredContentTest.php
+++ b/library/PostObject/Decorators/PostObjectWithFilteredContentTest.php
@@ -2,12 +2,18 @@
 
 namespace Municipio\PostObject\Decorators;
 
+use Municipio\Content\FilteredContentRuntimeCache;
 use Municipio\PostObject\PostObjectInterface;
 use PHPUnit\Framework\TestCase;
 use WpService\Implementations\FakeWpService;
 
 class PostObjectWithFilteredContentTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        FilteredContentRuntimeCache::clear();
+    }
+
     #[TestDox('class can be instantiated')]
     public function testClassCanBeInstantiated(): void
     {
@@ -27,8 +33,10 @@ class PostObjectWithFilteredContentTest extends TestCase
 
         $postObject = $this->createMock(PostObjectInterface::class);
         $postObject->method('getContent')->willReturn($rawContent);
+        $postObject->method('getId')->willReturn(123);
 
         $wpService = new FakeWpService([
+            'getCurrentBlogId' => 1,
             'applyFilters' => function ($hook, $content) use ($filteredContent) {
                 if ($hook === 'the_content') {
                     return $filteredContent;
@@ -75,8 +83,10 @@ class PostObjectWithFilteredContentTest extends TestCase
 
         $postObject = $this->createMock(PostObjectInterface::class);
         $postObject->method('getContent')->willReturn($rawContent);
+        $postObject->method('getId')->willReturn(123);
 
         $wpService = new FakeWpService([
+            'getCurrentBlogId' => 1,
             'applyFilters' => function ($hook, $content) {
                 // Mock the_excerpt and the_content filters
                 if ($hook === 'the_excerpt') {


### PR DESCRIPTION
This is a temporary patch that can be removed when old postObject is deprecated.