### PR TITLE
Fix async posts list pagination links

### DIFF
--- a/assets/source/js/postsList/PostsListAsync.ts
+++ b/assets/source/js/postsList/PostsListAsync.ts
@@ -65,10 +65,14 @@ export const postsListAsync = (
 		) => {
 			updateUrlParams(params, clearUrlParams);
 			const currentRequest = ++requestCount;
+			const requestParams = {
+				...params,
+				requestUri: `${window.location.pathname}${window.location.search}`,
+			};
 
 			try {
 				setIsLoading(true);
-				const html = await fetchHTML(params);
+				const html = await fetchHTML(requestParams);
 				const staleResponse = currentRequest !== requestCount;
 				if (staleResponse) return;
 				renderHTML(html);

--- a/library/Api/PostsList/PostsListRender.php
+++ b/library/Api/PostsList/PostsListRender.php
@@ -56,6 +56,7 @@ class PostsListRender extends RestApiEndpoint
     {
         $attributesJson = $request->get_param('attributes');
         $attributes = json_decode($attributesJson, true);
+        $requestUri = $request->get_param('requestUri');
 
         if (empty($attributes) || !is_array($attributes)) {
             $error = new WP_Error();
@@ -63,13 +64,7 @@ class PostsListRender extends RestApiEndpoint
             return rest_ensure_response($error);
         }
 
-        // Merge GET parameters into $_GET for filter/search/pagination support
-        $params = $request->get_params();
-        foreach ($params as $key => $value) {
-            if ($key !== 'attributes' && !isset($_GET[$key])) {
-                $_GET[$key] = $value;
-            }
-        }
+        $this->hydrateRequestGlobals($request->get_params(), $requestUri);
 
         try {
             $wpService  = WpService::get();
@@ -102,5 +97,21 @@ class PostsListRender extends RestApiEndpoint
     public function permissionCallback(): bool
     {
         return true;
+    }
+
+    /**
+     * Hydrates request globals used by downstream rendering.
+     */
+    protected function hydrateRequestGlobals(array $params, null|string $requestUri): void
+    {
+        if (is_string($requestUri) && str_starts_with($requestUri, '/')) {
+            $_SERVER['REQUEST_URI'] = $requestUri;
+        }
+
+        foreach ($params as $key => $value) {
+            if (!in_array($key, ['attributes', 'requestUri'], true) && !isset($_GET[$key])) {
+                $_GET[$key] = $value;
+            }
+        }
     }
 }

--- a/library/Api/PostsList/PostsListRenderTest.php
+++ b/library/Api/PostsList/PostsListRenderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Municipio\Api\PostsList;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PostsListRender::class)]
+class PostsListRenderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_GET    = [];
+        $_SERVER = [];
+    }
+
+    #[TestDox('hydrateRequestGlobals updates REQUEST_URI and excludes internal params from GET')]
+    public function testHydrateRequestGlobalsUsesArchiveRequestUri(): void
+    {
+        $sut = new class extends PostsListRender {
+            public function exposeHydrateRequestGlobals(array $params, ?string $requestUri): void
+            {
+                $this->hydrateRequestGlobals($params, $requestUri);
+            }
+        };
+
+        $sut->exposeHydrateRequestGlobals(
+            [
+                'attributes' => '{}',
+                'requestUri' => '/event?archive_page=2',
+                'archive_page' => '2',
+                'archive_category' => 'innovation',
+            ],
+            '/event?archive_page=2',
+        );
+
+        $this->assertSame('/event?archive_page=2', $_SERVER['REQUEST_URI']);
+        $this->assertSame('2', $_GET['archive_page']);
+        $this->assertSame('innovation', $_GET['archive_category']);
+        $this->assertArrayNotHasKey('attributes', $_GET);
+        $this->assertArrayNotHasKey('requestUri', $_GET);
+    }
+
+    #[TestDox('hydrateRequestGlobals ignores invalid request URIs')]
+    public function testHydrateRequestGlobalsIgnoresExternalRequestUri(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/existing';
+
+        $sut = new class extends PostsListRender {
+            public function exposeHydrateRequestGlobals(array $params, ?string $requestUri): void
+            {
+                $this->hydrateRequestGlobals($params, $requestUri);
+            }
+        };
+
+        $sut->exposeHydrateRequestGlobals(['archive_page' => '3'], 'https://example.com/not-local');
+
+        $this->assertSame('/existing', $_SERVER['REQUEST_URI']);
+        $this->assertSame('3', $_GET['archive_page']);
+    }
+}

--- a/library/PostsList/ViewCallableProviders/Pagination/GetPaginationComponentArgumentsTest.php
+++ b/library/PostsList/ViewCallableProviders/Pagination/GetPaginationComponentArgumentsTest.php
@@ -36,4 +36,24 @@ class GetPaginationComponentArgumentsTest extends TestCase
 
         $this->assertEquals([], $callableProvider->getCallable()());
     }
+
+    #[TestDox('It preserves existing query parameters when building pagination URLs')]
+    public function testGetPaginationComponentArgumentsPreservesExistingQueryParameters(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/event?archive_page=2&archive_category=innovation';
+
+        $callableProvider = new GetPaginationComponentArguments(2, 2, 'archive_page', 'archive-id');
+
+        $this->assertEquals(
+            [
+                'list' => [
+                    ['href' => '/event?archive_page=1&archive_category=innovation#archive-id', 'label' => '1'],
+                    ['href' => '/event?archive_page=2&archive_category=innovation#archive-id', 'label' => '2'],
+                ],
+                'current' => 2,
+                'linkPrefix' => 'archive_page',
+            ],
+            $callableProvider->getCallable()(),
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Preserve the archive request URI during async PostsList renders so pagination links continue to point back to the archive page instead of the REST endpoint.

## Changes
- send the current archive request URI with async pagination and filter requests
- reuse that URI in the PostsList render endpoint before pagination links are rebuilt
- add focused PHPUnit coverage for request-global hydration and pagination URL preservation

## Validation
- `php -l library/Api/PostsList/PostsListRender.php`
- `./vendor/bin/phpunit library/Api/PostsList/PostsListRenderTest.php library/PostsList/ViewCallableProviders/Pagination/GetPaginationComponentArgumentsTest.php`
- `npm run build:municipio`