### PR TITLE
Fix invalid Modularity CSS

### DIFF
--- a/Modularity/source/sass/partials/_editor.scss
+++ b/Modularity/source/sass/partials/_editor.scss
@@ -269,7 +269,7 @@
 
     &::before {
         content: ""; 
-        background: linear-gradient(0, rgba(255, 255, 255, 0),#FFFFFF);
+        background: linear-gradient(0deg, rgba(255, 255, 255, 0),#FFFFFF);
         top: 38px; 
         right: 0;
         left: 0;

--- a/Modularity/source/sass/partials/_editor.scss
+++ b/Modularity/source/sass/partials/_editor.scss
@@ -302,7 +302,6 @@
 
             .modularity-modules {
                 height: 100%;
-                min-height: unset;
                 max-height: unset;
             }
         }

--- a/Modularity/source/sass/partials/_editor.scss
+++ b/Modularity/source/sass/partials/_editor.scss
@@ -302,7 +302,7 @@
 
             .modularity-modules {
                 height: 100%;
-                min-height: none;
+                min-height: unset;
                 max-height: unset;
             }
         }

--- a/Modularity/source/sass/partials/_modules.scss
+++ b/Modularity/source/sass/partials/_modules.scss
@@ -48,14 +48,6 @@ $module-line-height: 48px;
     }
 }
 
-li.modularity-module {
-    line-height: auto;
-
-    >span {
-        line-height: auto;
-    }
-}
-
 .modularity-modules .modularity-module-name,
 .ui-draggable-dragging .modularity-module-name {
     display: block;


### PR DESCRIPTION
The bundled Modularity stylesheet contains ineffective `line-height: auto` and `min-height: none` declarations, plus a unitless zero angle in a linear gradient. Browsers ignore the invalid declarations, and the generated stylesheet fails CSS validation.

This change removes the ineffective declarations and expresses the gradient angle as `0deg`. Existing inherited line height and rendered layout remain unchanged.
