### PR TITLE
Keep the fixed Modularity panel visible

### DIFF
--- a/Modularity/source/sass/partials/_editor.scss
+++ b/Modularity/source/sass/partials/_editor.scss
@@ -299,6 +299,7 @@
         @media screen and (min-width: 851px) {
             position: fixed;
             top: 40px;
+            inset-inline-end: 20px;
             width: 280px;
             z-index: 100;
 

--- a/Modularity/source/sass/partials/_editor.scss
+++ b/Modularity/source/sass/partials/_editor.scss
@@ -299,6 +299,8 @@
         @media screen and (min-width: 851px) {
             position: fixed;
             top: 40px;
+            width: 280px;
+            z-index: 100;
 
             .modularity-modules {
                 height: 100%;

--- a/assets/source/sass/admin/general.scss
+++ b/assets/source/sass/admin/general.scss
@@ -21,7 +21,6 @@
 .notice-success,
 .notice-error,
 #screen-meta-links > *,
-.meta-box-sortables,
 .nestedpages,
 .page-title-action,
 .np-button,


### PR DESCRIPTION
The Modularity module picker switches to fixed positioning after its scroll threshold, but the general admin stylesheet applies `filter: drop-shadow(...)` to its `.meta-box-sortables` ancestor. A filtered ancestor becomes the containing block for fixed descendants, so the picker's `top` offset is calculated in document coordinates and it scrolls out of the viewport. The picker also loses the width supplied by WordPress's sidebar layout and has no explicit horizontal viewport anchor.

This change removes the redundant filter from the transparent sortable container while keeping the same drop shadow on each actual postbox. It also retains the sidebar's 280-pixel width, anchors the picker to the viewport's logical inline edge, and places it above the editor content. The existing breakpoint, scroll behavior, panel height, and drag-and-drop interaction remain unchanged.
