### PR TITLE
feat:remove temporary file renaming on s3 clusters

### DIFF
--- a/Test/ImageConvert/TestImageStreamWrapper.php
+++ b/Test/ImageConvert/TestImageStreamWrapper.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Test\ImageConvert;
+
+class TestImageStreamWrapper
+{
+    public static array $files = [];
+    public static array $writtenPaths = [];
+    private string $path = '';
+    private int $position = 0;
+
+    public static function reset(): void
+    {
+        self::$files = [];
+        self::$writtenPaths = [];
+    }
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        $parts          = parse_url($path);
+        $this->path     = ltrim(($parts['host'] ?? '') . '/' . ltrim($parts['path'] ?? '', '/'), '/');
+        $this->position = 0;
+
+        if (str_contains($mode, 'w')) {
+            self::$files[$this->path] = '';
+            self::$writtenPaths[]     = $path;
+        }
+
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        self::$files[$this->path] .= $data;
+        $this->position          += strlen($data);
+
+        return strlen($data);
+    }
+
+    public function stream_read(int $count): string
+    {
+        $data = substr(self::$files[$this->path] ?? '', $this->position, $count);
+        $this->position += strlen($data);
+
+        return $data;
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->position >= strlen(self::$files[$this->path] ?? '');
+    }
+
+    public function stream_stat(): array
+    {
+        return [];
+    }
+}

--- a/library/ImageConvert/ImageProcessor.php
+++ b/library/ImageConvert/ImageProcessor.php
@@ -110,12 +110,9 @@ class ImageProcessor
             return false;
         }
 
-        $publishTemporaryPath = null;
-
         try {
             // S3-backed stream wrappers cannot always inspect a newly written
-            // object immediately. Generate and validate locally, then stage a
-            // temporary object beside the final image before publication.
+            // object immediately. Generate and validate locally before publication.
             $savedImage = $imageEditor->save($localTemporaryPath);
             if ($this->wpService->isWpError($savedImage)) {
                 $this->logConversionFailure($image, $format, $savedImage);
@@ -139,20 +136,11 @@ class ImageProcessor
                 return false;
             }
 
-            $publishTemporaryPath = $savedPath;
-            if ($usesExternalStream) {
-                $publishTemporaryPath = $this->getTemporaryPath($intermediateLocation['path']);
-                if (!copy($savedPath, $publishTemporaryPath)) {
-                    $this->logConversionFailure(
-                        $image,
-                        $format,
-                        new \WP_Error('publish_failed', 'The converted image could not be published to its public path.'),
-                    );
-                    return false;
-                }
-            }
+            $publishedImage = $usesExternalStream
+                ? copy($savedPath, $intermediateLocation['path'])
+                : rename($savedPath, $intermediateLocation['path']);
 
-            if (!rename($publishTemporaryPath, $intermediateLocation['path'])) {
+            if (!$publishedImage) {
                 $this->logConversionFailure(
                     $image,
                     $format,
@@ -160,8 +148,6 @@ class ImageProcessor
                 );
                 return false;
             }
-
-            $publishTemporaryPath = null;
 
             $intermediateLocation['path'] = $this->wpService->applyFilters(
                 'wp_create_file_in_uploads',
@@ -181,10 +167,8 @@ class ImageProcessor
 
             return $image;
         } finally {
-            foreach ([$localTemporaryPath, $publishTemporaryPath] as $temporaryPath) {
-                if ($temporaryPath !== null && file_exists($temporaryPath)) {
-                    $this->wpService->wpDeleteFile($temporaryPath);
-                }
+            if (file_exists($localTemporaryPath)) {
+                $this->wpService->wpDeleteFile($localTemporaryPath);
             }
         }
     }
@@ -226,7 +210,7 @@ class ImageProcessor
         $extension = pathinfo($finalPath, PATHINFO_EXTENSION);
         $basePath = substr($finalPath, 0, -(strlen($extension) + 1));
 
-        return sprintf('%s.tmp-%s.%s', $basePath, bin2hex(random_bytes(8)), $extension);
+        return sprintf('%s.tmp-%s.%s', $basePath, bin2hex(\random_bytes(8)), $extension);
     }
 
     private function logConversionFailure(ImageContract $image, string $format, \WP_Error $error): void

--- a/library/ImageConvert/ImageProcessorTest.php
+++ b/library/ImageConvert/ImageProcessorTest.php
@@ -2,8 +2,20 @@
 
 namespace Municipio\ImageConvert;
 
+use Municipio\ImageConvert\Cache\ConversionCache;
+use Municipio\ImageConvert\Config\ImageConvertConfig;
 use Municipio\ImageConvert\Contract\ImageContract;
+use Municipio\ImageConvert\Logging\Log;
+use Municipio\Test\ImageConvert\TestImageStreamWrapper;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use WpService\Contracts\AddFilter;
+use WpService\Contracts\ApplyFilters;
+use WpService\Contracts\IsWpError;
+use WpService\Contracts\WpAttachmentIs;
+use WpService\Contracts\WpDeleteFile;
+use WpService\Contracts\WpGetAttachmentMetadata;
+use WpService\Contracts\WpGetImageEditor;
 
 class ImageProcessorTest extends TestCase
 {
@@ -36,12 +48,117 @@ class ImageProcessorTest extends TestCase
         $this->assertSame(2_107_269, $size);
     }
 
+    public function testConvertsExternalStreamThroughLocalValidationBeforePublishingFinalPath(): void
+    {
+        TestImageStreamWrapper::reset();
+        stream_wrapper_register('municipio-test-image', TestImageStreamWrapper::class);
+
+        try {
+            $fixturePath = $this->createValidWebpFixture();
+            $imageEditor = $this->createMock(\WP_Image_Editor::class);
+            $imageEditor->method('get_size')->willReturn([
+                'width'  => 1,
+                'height' => 1,
+            ]);
+            $imageEditor->method('resize')->willReturn(true);
+            $imageEditor->method('save')->willReturnCallback(static function (string $destinationPath) use ($fixturePath): array {
+                copy($fixturePath, $destinationPath);
+
+                return [
+                    'path'      => $destinationPath,
+                    'file'      => basename($destinationPath),
+                    'width'     => 1,
+                    'height'    => 1,
+                    'mime-type' => 'image/webp',
+                    'filesize'  => filesize($destinationPath),
+                ];
+            });
+
+            /** @var WpGetImageEditor&IsWpError&WpGetAttachmentMetadata&WpAttachmentIs&AddFilter&ApplyFilters&WpDeleteFile&MockObject $wpService */
+            $wpService = $this->createMockForIntersectionOfInterfaces([
+                WpGetImageEditor::class,
+                IsWpError::class,
+                WpGetAttachmentMetadata::class,
+                WpAttachmentIs::class,
+                AddFilter::class,
+                ApplyFilters::class,
+                WpDeleteFile::class,
+            ]);
+            $wpService->method('wpGetImageEditor')->willReturn($imageEditor);
+            $wpService->method('isWpError')->willReturn(false);
+            $wpService->method('applyFilters')->willReturnArgument(1);
+            $wpService->expects(static::once())->method('wpDeleteFile')->willReturnCallback(static function (string $path): void {
+                if (file_exists($path)) {
+                    unlink($path);
+                }
+            });
+
+            $image = $this->createMock(ImageContract::class);
+            $image->method('getPath')->willReturn('/original/image.jpg');
+            $image->method('getWidth')->willReturn(425);
+            $image->method('getHeight')->willReturn(239);
+            $image->method('getIntermidiateLocation')->with('webp')->willReturn([
+                'path' => 'municipio-test-image://uploads/Feature_32486-425x239.webp',
+                'url'  => 'https://media.example/uploads/Feature_32486-425x239.webp',
+            ]);
+            $image->expects(static::once())->method('setUrl')->with('https://media.example/uploads/Feature_32486-425x239.webp');
+            $image->expects(static::once())->method('setPath')->with('municipio-test-image://uploads/Feature_32486-425x239.webp');
+
+            $conversionCache = $this->createMock(ConversionCache::class);
+            $conversionCache->expects(static::once())->method('markConversionSuccess')->with($image);
+
+            $processor = new ImageProcessor(
+                $wpService,
+                $this->createMock(ImageConvertConfig::class),
+                $conversionCache,
+                $this->createMock(Log::class),
+            );
+
+            $result = $this->invokePrivateMethod(
+                'convertImage',
+                $image,
+                'webp',
+                $processor,
+            );
+
+            static::assertSame($image, $result);
+            static::assertSame(
+                ['municipio-test-image://uploads/Feature_32486-425x239.webp'],
+                TestImageStreamWrapper::$writtenPaths,
+            );
+            static::assertSame(
+                [],
+                array_filter(
+                    TestImageStreamWrapper::$writtenPaths,
+                    static fn(string $path): bool => str_contains($path, '.tmp-'),
+                ),
+            );
+            unlink($fixturePath);
+        } finally {
+            stream_wrapper_unregister('municipio-test-image');
+        }
+    }
+
     private function invokePrivateMethod(string $method, mixed ...$arguments): mixed
     {
         $reflection = new \ReflectionClass(ImageProcessor::class);
-        $processor = $reflection->newInstanceWithoutConstructor();
+        $processor = end($arguments) instanceof ImageProcessor ? array_pop($arguments) : $reflection->newInstanceWithoutConstructor();
         $methodReflection = $reflection->getMethod($method);
 
         return $methodReflection->invoke($processor, ...$arguments);
+    }
+
+    private function createValidWebpFixture(): string
+    {
+        $sourcePath = tempnam(sys_get_temp_dir(), 'municipio-webp-fixture-');
+        static::assertIsString($sourcePath);
+        $sourcePath .= '.webp';
+
+        file_put_contents(
+            $sourcePath,
+            base64_decode('UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AA/vuUAAA=', true),
+        );
+
+        return $sourcePath;
     }
 }


### PR DESCRIPTION
This PR updates the image conversion publish flow for external storage-backed uploads.

Previously, converted images were first generated and validated locally, but then also staged as `.tmp-*` files in the external storage path before being renamed to the final filename. In Swift-backed storage this could expose temporary objects such as:

```text
/uploads/networks/1/sites/10015/2026/09/Feature_32486-425x239.tmp-cce5c3d7e28fca8a.webp
```

The updated flow keeps temporary conversion and validation local, then publishes the verified image directly to the final external storage path.

## What Changed
Convert resized images into the local system temp directory.
Validate the converted image locally before publication.
For external stream wrappers, copy the verified image directly to the final destination path.
Avoid creating .tmp-* files in Swift/external storage.
Clean up the local temporary file after processing.
Add test coverage to verify that external publishing writes only the final path and no remote .tmp-* path.

## Why
Temporary files should stay local during conversion and verification. External storage should only receive the final, verified image. This avoids leaking temporary objects into Swift, reduces storage noise, and prevents .tmp-* paths from appearing in traces, logs, or public media paths.

## Verification
./vendor/bin/phpunit --filter ImageProcessorTest passes.
mago lint was run against the touched files. It still reports existing complexity/style findings in ImageProcessor, unrelated to this behavior change.
