### PR TITLE
fix: allow design import from another site

### DIFF
--- a/assets/source/js/admin/designShareUtils.ts
+++ b/assets/source/js/admin/designShareUtils.ts
@@ -44,9 +44,13 @@ type DesignShareConfig = {
 };
 
 function getAllowedSettingConfig(): DesignShareConfig {
-	return (window as Window & {
-		municipioDesignShareConfig?: DesignShareConfig;
-	}).municipioDesignShareConfig ?? {};
+	return (
+		(
+			window as Window & {
+				municipioDesignShareConfig?: DesignShareConfig;
+			}
+		).municipioDesignShareConfig ?? {}
+	);
 }
 
 function getAllowedExactKeys(): string[] {
@@ -137,7 +141,9 @@ function buildImportProxyEndpointUrl(rawSiteUrl: unknown): string {
 	return endpointUrl.toString();
 }
 
-function isValidRemoteDesignConfig(payload: unknown): payload is RemoteDesignConfig {
+function isValidRemoteDesignConfig(
+	payload: unknown,
+): payload is RemoteDesignConfig {
 	if (payload === null || typeof payload !== "object") {
 		return false;
 	}
@@ -186,7 +192,6 @@ export async function getRemoteSiteDesignData(
 		response = await fetch(endpointUrl, {
 			headers: {
 				Accept: "application/json",
-				// Required for the cookie-authenticated permission check on the proxy route
 				"X-WP-Nonce": wpApiSettings?.nonce ?? "",
 			},
 		});
@@ -255,9 +260,7 @@ export function showNotification(args: CustomizerNotificationProps) {
 	args.setting.notifications.add(args.code, notification);
 }
 
-export async function getFormattedMods(
-	mods: CustomizerMods,
-) {
+export async function getFormattedMods(mods: CustomizerMods) {
 	const formattedMods: CustomizerMods = {};
 
 	for (const [key, value] of Object.entries(mods)) {
@@ -281,9 +284,7 @@ export async function getFormattedMods(
 	return formattedMods;
 }
 
-export async function importSettings(
-	formattedMods: CustomizerMods,
-) {
+export async function importSettings(formattedMods: CustomizerMods) {
 	for (const [key, rawValue] of Object.entries(formattedMods)) {
 		if (!isAllowedImportSettingKey(key)) {
 			continue;

--- a/assets/source/js/admin/designShareUtils.ts
+++ b/assets/source/js/admin/designShareUtils.ts
@@ -186,6 +186,8 @@ export async function getRemoteSiteDesignData(
 		response = await fetch(endpointUrl, {
 			headers: {
 				Accept: "application/json",
+				// Required for the cookie-authenticated permission check on the proxy route
+				"X-WP-Nonce": wpApiSettings?.nonce ?? "",
 			},
 		});
 	} catch (error) {

--- a/library/Theme/Enqueue.php
+++ b/library/Theme/Enqueue.php
@@ -126,7 +126,7 @@ class Enqueue implements Hookable
     public function enqueueCustomizerScriptsAndStyles()
     {
         $this->enqueue
-            ->add('js/design-share.js', ['jquery', 'customize-controls'])
+            ->add('js/design-share.js', ['jquery', 'customize-controls', 'wp-api-request'])
             ->with()
             ->translation('municipioDesignShareConfig', [
                 'minimumSupportedDbVersion' => (int) get_option('municipio_db_version', 0),


### PR DESCRIPTION
Adds the missing X-WP-Nonce header to the Design Library "import design" REST proxy request, and ensures the required wp-api-request script (which supplies that nonce) is actually loaded on the Customizer screen.

## Why
The "Import design" feature in the Customizer lets an admin pull design tokens/CSS from another Municipio site (e.g. helsingborg.se) through a server-side proxy endpoint. 

WordPress's REST API cookie authentication requires the request to include a valid X-WP-Nonce header — without it, the current user resolves to "logged out" for that request even though the browser sends the auth cookies. This is documented WP core behavior, not a bug in WordPress itself.

Because the original fetch() call in getRemoteSiteDesignData() only sent an Accept header, every import attempt was rejected by the permission check and the UI always surfaced the generic "We cannot import from this site" error — regardless of whether the source site (including a fully compatible helsingborg.se) was reachable or version-compatible. I confirmed the remote site's config endpoint itself was healthy and returning valid, version-compatible data, which ruled out the source site as the cause and pointed to the local permission check.

The fix follows the same pattern already used elsewhere in the codebase (restApi/newEndpoint.ts, restApi/wpApiSettings.ts, userEditableList.ts) of attaching wpApiSettings.nonce as X-WP-Nonce.
