### PR TITLE
Feat/fonts in design library

### DIFF
--- a/assets/source/js/admin/designShareUtils.ts
+++ b/assets/source/js/admin/designShareUtils.ts
@@ -44,9 +44,13 @@ type DesignShareConfig = {
 };
 
 function getAllowedSettingConfig(): DesignShareConfig {
-	return (window as Window & {
-		municipioDesignShareConfig?: DesignShareConfig;
-	}).municipioDesignShareConfig ?? {};
+	return (
+		(
+			window as Window & {
+				municipioDesignShareConfig?: DesignShareConfig;
+			}
+		).municipioDesignShareConfig ?? {}
+	);
 }
 
 function getAllowedExactKeys(): string[] {
@@ -137,7 +141,9 @@ function buildImportProxyEndpointUrl(rawSiteUrl: unknown): string {
 	return endpointUrl.toString();
 }
 
-function isValidRemoteDesignConfig(payload: unknown): payload is RemoteDesignConfig {
+function isValidRemoteDesignConfig(
+	payload: unknown,
+): payload is RemoteDesignConfig {
 	if (payload === null || typeof payload !== "object") {
 		return false;
 	}
@@ -186,7 +192,6 @@ export async function getRemoteSiteDesignData(
 		response = await fetch(endpointUrl, {
 			headers: {
 				Accept: "application/json",
-				// Required for the cookie-authenticated permission check on the proxy route
 				"X-WP-Nonce": wpApiSettings?.nonce ?? "",
 			},
 		});
@@ -255,9 +260,7 @@ export function showNotification(args: CustomizerNotificationProps) {
 	args.setting.notifications.add(args.code, notification);
 }
 
-export async function getFormattedMods(
-	mods: CustomizerMods,
-) {
+export async function getFormattedMods(mods: CustomizerMods) {
 	const formattedMods: CustomizerMods = {};
 
 	for (const [key, value] of Object.entries(mods)) {
@@ -281,9 +284,7 @@ export async function getFormattedMods(
 	return formattedMods;
 }
 
-export async function importSettings(
-	formattedMods: CustomizerMods,
-) {
+export async function importSettings(formattedMods: CustomizerMods) {
 	for (const [key, rawValue] of Object.entries(formattedMods)) {
 		if (!isAllowedImportSettingKey(key)) {
 			continue;

--- a/assets/source/js/admin/designShareUtils.ts
+++ b/assets/source/js/admin/designShareUtils.ts
@@ -1,3 +1,4 @@
+import { activateFont } from "../restApi/endpoints/activateFont";
 import type { MediaSideloadArgs } from "../restApi/endpoints/mediaSideload";
 import { mediaSideload } from "../restApi/endpoints/mediaSideload";
 import { isRemoteMediaFile } from "../utils/isRemoteMediaFile";
@@ -91,6 +92,22 @@ function isAllowedImportSettingKey(key: string): boolean {
 
 function hasOwn(object: object, property: string): boolean {
 	return Object.hasOwn(object, property);
+}
+
+type FontFaceVariant = {
+	fontWeight: string;
+	fontStyle: string;
+	src: string;
+};
+
+function isFontFaceVariant(value: unknown): value is FontFaceVariant {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		typeof (value as FontFaceVariant).fontWeight === "string" &&
+		typeof (value as FontFaceVariant).fontStyle === "string" &&
+		typeof (value as FontFaceVariant).src === "string"
+	);
 }
 
 export async function handleMediaSideload(args: MediaSideloadArgs) {
@@ -303,14 +320,24 @@ export async function importSettings(formattedMods: CustomizerMods) {
 			continue;
 		}
 
-		if (key.startsWith("custom_fonts") && typeof value === "string") {
+		if (key.startsWith("custom_fonts") && Array.isArray(value)) {
 			const fontName = key.match(/\[(.+)\]$/);
 			if (fontName === null) continue;
-			await handleMediaSideload({
-				url: value,
-				description: fontName[1],
-				return: "id",
-			});
+
+			for (const variant of value) {
+				if (!isFontFaceVariant(variant)) continue;
+				await activateFont
+					.call({
+						fontFamily: fontName[1],
+						fontWeight: variant.fontWeight,
+						fontStyle: variant.fontStyle,
+						url: variant.src,
+					})
+					.catch((error) => {
+						console.error(error);
+						return null;
+					});
+			}
 		} else if (typeof control !== "undefined") {
 			if (typeof value === "string" && isRemoteMediaFile(value)) {
 				await migrateRemoteMediaFile(value, control);

--- a/assets/source/js/admin/designShareUtils.ts
+++ b/assets/source/js/admin/designShareUtils.ts
@@ -186,6 +186,8 @@ export async function getRemoteSiteDesignData(
 		response = await fetch(endpointUrl, {
 			headers: {
 				Accept: "application/json",
+				// Required for the cookie-authenticated permission check on the proxy route
+				"X-WP-Nonce": wpApiSettings?.nonce ?? "",
 			},
 		});
 	} catch (error) {

--- a/assets/source/js/restApi/endpoints/activateFont.ts
+++ b/assets/source/js/restApi/endpoints/activateFont.ts
@@ -1,0 +1,22 @@
+import type { ApiCallArgs } from "../newEndpoint";
+import { NameSpace, newEndpoint } from "../newEndpoint";
+
+export interface ActivateFontArgs extends ApiCallArgs {
+	fontFamily: string;
+	fontWeight?: string;
+	fontStyle?: string;
+	url: string;
+}
+
+export interface ActivateFontResponse {
+	success: boolean;
+	fontFamilyId: number;
+}
+
+export const activateFont = newEndpoint<ActivateFontResponse, ActivateFontArgs>(
+	{
+		nameSpace: NameSpace.MUNICIPIO_V1,
+		route: "design-library/activate-font",
+		method: "POST",
+	},
+);

--- a/library/Api/Customizer/DesignLibrary.php
+++ b/library/Api/Customizer/DesignLibrary.php
@@ -6,304 +6,310 @@ use Municipio\Api\RestApiEndpoint;
 use Municipio\Customizer\DesignLibrarySettingPolicy;
 use WP_Error;
 use WP_Http;
-use WP_REST_Response;
 use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 
 class DesignLibrary extends RestApiEndpoint
 {
-	private const NAMESPACE = 'municipio/v1';
-	private const ROUTE_CONFIG = 'design-library/config';
-	private const ROUTE_IMPORT_PROXY = 'design-library/import';
+    private const NAMESPACE = 'municipio/v1';
+    private const ROUTE_CONFIG = 'design-library/config';
+    private const ROUTE_IMPORT_PROXY = 'design-library/import';
 
-	private const SETTINGS_EXCLUDED_FROM_EXPORT = [
-		'load_design',
-		'exclude_load_design',
-		'load_design_site_url',
-		'municipio_font_catalog_uploaded_fonts',
-		'municipio_font_catalog_migrated',
-	];
+    private const SETTINGS_EXCLUDED_FROM_EXPORT = [
+        'load_design',
+        'exclude_load_design',
+        'load_design_site_url',
+        'municipio_font_catalog_uploaded_fonts',
+        'municipio_font_catalog_migrated',
+    ];
 
-	public function handleRegisterRestRoute(): bool
-	{
-		$configRouteRegistered = register_rest_route(self::NAMESPACE, self::ROUTE_CONFIG, [
-			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => [$this, 'handleRequest'],
-			'permission_callback' => [$this, 'permissionCallback'],
-		]);
+    public function handleRegisterRestRoute(): bool
+    {
+        $configRouteRegistered = register_rest_route(self::NAMESPACE, self::ROUTE_CONFIG, [
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => [$this, 'handleRequest'],
+            'permission_callback' => [$this, 'permissionCallback'],
+        ]);
 
-		$importRouteRegistered = register_rest_route(self::NAMESPACE, self::ROUTE_IMPORT_PROXY, [
-			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => [$this, 'handleImportRequest'],
-			'permission_callback' => [$this, 'importPermissionCallback'],
-			'args'                => [
-				'source' => [
-					'description' => __('Source Municipio site URL.', 'municipio'),
-					'type' => 'string',
-					'required' => true,
-				],
-			],
-		]);
+        $importRouteRegistered = register_rest_route(self::NAMESPACE, self::ROUTE_IMPORT_PROXY, [
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => [$this, 'handleImportRequest'],
+            'permission_callback' => [$this, 'importPermissionCallback'],
+            'args' => [
+                'source' => [
+                    'description' => __('Source Municipio site URL.', 'municipio'),
+                    'type' => 'string',
+                    'required' => true,
+                ],
+            ],
+        ]);
 
-		return $configRouteRegistered && $importRouteRegistered;
-	}
+        return $configRouteRegistered && $importRouteRegistered;
+    }
 
-	public function handleRequest(WP_REST_Request $request)
-	{
-		$response = rest_ensure_response($this->getSiteConfig());
+    public function handleRequest(WP_REST_Request $request)
+    {
+        $response = rest_ensure_response($this->getSiteConfig());
 
-		if ($response instanceof WP_REST_Response) {
-			$response->header('Access-Control-Allow-Origin', '*');
-			$response->header('Access-Control-Allow-Methods', 'GET, OPTIONS');
-			$response->header('Access-Control-Allow-Headers', 'Content-Type, X-WP-Nonce, Authorization');
-		}
+        if ($response instanceof WP_REST_Response) {
+            $response->header('Access-Control-Allow-Origin', '*');
+            $response->header('Access-Control-Allow-Methods', 'GET, OPTIONS');
+            $response->header('Access-Control-Allow-Headers', 'Content-Type, X-WP-Nonce, Authorization');
+        }
 
-		return $response;
-	}
+        return $response;
+    }
 
-	public function permissionCallback(): bool
-	{
-		return true;
-	}
+    public function permissionCallback(): bool
+    {
+        return true;
+    }
 
-	/**
-	 * Proxy import callback. Fetches remote design config server-side to avoid browser CORS issues.
-	 *
-	 * @return WP_REST_Response|WP_Error
-	 */
-	public function handleImportRequest(WP_REST_Request $request)
-	{
-		$sourceSiteUrl = $request->get_param('source');
+    /**
+     * Proxy import callback. Fetches remote design config server-side to avoid browser CORS issues.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function handleImportRequest(WP_REST_Request $request)
+    {
+        $sourceSiteUrl = $request->get_param('source');
 
-		if (!is_string($sourceSiteUrl) || trim($sourceSiteUrl) === '') {
-			return new WP_Error(
-				'municipio_design_import_missing_source',
-				__('Missing source URL.', 'municipio'),
-				['status' => WP_Http::BAD_REQUEST],
-			);
-		}
+        if (!is_string($sourceSiteUrl) || trim($sourceSiteUrl) === '') {
+            return new WP_Error(
+                'municipio_design_import_missing_source',
+                __('Missing source URL.', 'municipio'),
+                ['status' => WP_Http::BAD_REQUEST],
+            );
+        }
 
-		$normalizedSourceUrl = $this->normalizeSourceSiteUrl($sourceSiteUrl);
+        $normalizedSourceUrl = $this->normalizeSourceSiteUrl($sourceSiteUrl);
 
-		if ($normalizedSourceUrl === null) {
-			return new WP_Error(
-				'municipio_design_import_invalid_source',
-				__('Invalid source URL.', 'municipio'),
-				['status' => WP_Http::BAD_REQUEST],
-			);
-		}
+        if ($normalizedSourceUrl === null) {
+            return new WP_Error(
+                'municipio_design_import_invalid_source',
+                __('Invalid source URL.', 'municipio'),
+                ['status' => WP_Http::BAD_REQUEST],
+            );
+        }
 
-		$cacheBust = $request->get_param('cache-bust');
-		$cacheBust = is_string($cacheBust) && $cacheBust !== '' ? $cacheBust : uniqid('import-', true);
+        $cacheBust = $request->get_param('cache-bust');
+        $cacheBust = is_string($cacheBust) && $cacheBust !== '' ? $cacheBust : uniqid('import-', true);
 
-		$remoteConfigUrl = $this->buildRemoteConfigUrl($normalizedSourceUrl, $cacheBust);
-		$remoteResponse = wp_remote_get($remoteConfigUrl, [
-			'timeout' => 10,
-			'headers' => [
-				'Accept' => 'application/json',
-			],
-		]);
+        $remoteConfigUrl = $this->buildRemoteConfigUrl($normalizedSourceUrl, $cacheBust);
+        $remoteResponse = wp_remote_get($remoteConfigUrl, [
+            'timeout' => 10,
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+        ]);
 
-		if (is_wp_error($remoteResponse)) {
-			return new WP_Error(
-				'municipio_design_import_fetch_failed',
-				__('Unable to fetch design data from the source site.', 'municipio'),
-				['status' => WP_Http::BAD_GATEWAY],
-			);
-		}
+        if (is_wp_error($remoteResponse)) {
+            return new WP_Error(
+                'municipio_design_import_fetch_failed',
+                __('Unable to fetch design data from the source site.', 'municipio'),
+                ['status' => WP_Http::BAD_GATEWAY],
+            );
+        }
 
-		$statusCode = (int) wp_remote_retrieve_response_code($remoteResponse);
-		$rawBody = (string) wp_remote_retrieve_body($remoteResponse);
+        $statusCode = (int) wp_remote_retrieve_response_code($remoteResponse);
+        $rawBody = (string) wp_remote_retrieve_body($remoteResponse);
 
-		if ($statusCode < 200 || $statusCode >= 300) {
-			return new WP_Error(
-				'municipio_design_import_remote_status',
-				__('The source site returned an invalid response.', 'municipio'),
-				['status' => WP_Http::BAD_GATEWAY],
-			);
-		}
+        if ($statusCode < 200 || $statusCode >= 300) {
+            return new WP_Error(
+                'municipio_design_import_remote_status',
+                __('The source site returned an invalid response.', 'municipio'),
+                ['status' => WP_Http::BAD_GATEWAY],
+            );
+        }
 
-		$decodedBody = json_decode($rawBody, true);
+        $decodedBody = json_decode($rawBody, true);
 
-		if (!is_array($decodedBody)) {
-			return new WP_Error(
-				'municipio_design_import_invalid_payload',
-				__('The source site returned invalid design data.', 'municipio'),
-				['status' => WP_Http::BAD_GATEWAY],
-			);
-		}
+        if (!is_array($decodedBody)) {
+            return new WP_Error(
+                'municipio_design_import_invalid_payload',
+                __('The source site returned invalid design data.', 'municipio'),
+                ['status' => WP_Http::BAD_GATEWAY],
+            );
+        }
 
-		return rest_ensure_response($decodedBody);
-	}
+        return rest_ensure_response($decodedBody);
+    }
 
-	/**
-	 * Restrict proxy import to authenticated users with Customizer capability.
-	 */
-	public function importPermissionCallback(): bool
-	{
-		return is_user_logged_in() && current_user_can('customize');
-	}
+    /**
+     * Restrict proxy import to authenticated users with Customizer capability.
+     */
+    public function importPermissionCallback(): bool
+    {
+        return is_user_logged_in() && current_user_can('customize');
+    }
 
-	private function normalizeSourceSiteUrl(string $sourceSiteUrl): ?string
-	{
-		$trimmedUrl = trim($sourceSiteUrl);
+    private function normalizeSourceSiteUrl(string $sourceSiteUrl): ?string
+    {
+        $trimmedUrl = trim($sourceSiteUrl);
 
-		if (!preg_match('/^https?:\/\//i', $trimmedUrl)) {
-			$trimmedUrl = 'https://' . $trimmedUrl;
-		}
+        if (!preg_match('/^https?:\/\//i', $trimmedUrl)) {
+            $trimmedUrl = 'https://' . $trimmedUrl;
+        }
 
-		if (!wp_http_validate_url($trimmedUrl)) {
-			return null;
-		}
+        if (!wp_http_validate_url($trimmedUrl)) {
+            return null;
+        }
 
-		$scheme = wp_parse_url($trimmedUrl, PHP_URL_SCHEME);
-		if (!is_string($scheme) || !in_array(strtolower($scheme), ['http', 'https'], true)) {
-			return null;
-		}
+        $scheme = wp_parse_url($trimmedUrl, PHP_URL_SCHEME);
+        if (!is_string($scheme) || !in_array(strtolower($scheme), ['http', 'https'], true)) {
+            return null;
+        }
 
-		return $trimmedUrl;
-	}
+        return $trimmedUrl;
+    }
 
-	private function buildRemoteConfigUrl(string $sourceSiteUrl, string $cacheBust): string
-	{
-		$remoteConfigUrl = rtrim($sourceSiteUrl, '/') . '/wp-json/municipio/v1/design-library/config';
-		return add_query_arg('cache-bust', $cacheBust, $remoteConfigUrl);
-	}
+    private function buildRemoteConfigUrl(string $sourceSiteUrl, string $cacheBust): string
+    {
+        $remoteConfigUrl = rtrim($sourceSiteUrl, '/') . '/wp-json/municipio/v1/design-library/config';
+        return add_query_arg('cache-bust', $cacheBust, $remoteConfigUrl);
+    }
 
-	/**
-	 * Build a design import payload for this site.
-	 *
-	 * @return array<string, mixed>
-	 */
-	protected function getSiteConfig(): array
-	{
-		return [
-			'uuid' => md5(ABSPATH . get_home_url()),
-			'website' => get_home_url(),
-			'name' => get_bloginfo('name'),
-			'dbVersion' => (int) get_option('municipio_db_version', 0),
-			'municipioVersion' => wp_get_theme()->get('Version'),
-			'allowedSettingKeys' => DesignLibrarySettingPolicy::getAllowedExactKeys(),
-			'allowedSettingKeyPrefixes' => DesignLibrarySettingPolicy::getAllowedPrefixes(),
-			'mods' => $this->getShareableThemeMods(),
-			'css' => wp_get_custom_css() ?? false,
-		];
-	}
+    /**
+     * Build a design import payload for this site.
+     *
+     * @return array<string, mixed>
+     */
+    protected function getSiteConfig(): array
+    {
+        return [
+            'uuid' => md5(ABSPATH . get_home_url()),
+            'website' => get_home_url(),
+            'name' => get_bloginfo('name'),
+            'dbVersion' => (int) get_option('municipio_db_version', 0),
+            'municipioVersion' => wp_get_theme()->get('Version'),
+            'allowedSettingKeys' => DesignLibrarySettingPolicy::getAllowedExactKeys(),
+            'allowedSettingKeyPrefixes' => DesignLibrarySettingPolicy::getAllowedPrefixes(),
+            'mods' => $this->getShareableThemeMods(),
+            'css' => wp_get_custom_css() ?? false,
+        ];
+    }
 
-	/**
-	 * Get theme mods that can be safely imported by the design tool.
-	 *
-	 * @return array<string, mixed>
-	 */
-	private function getShareableThemeMods(): array
-	{
-		$mods = get_theme_mods();
+    /**
+     * Get theme mods that can be safely imported by the design tool.
+     *
+     * @return array<string, mixed>
+     */
+    private function getShareableThemeMods(): array
+    {
+        $mods = get_theme_mods();
 
-		if (!is_array($mods)) {
-			return [];
-		}
+        if (!is_array($mods)) {
+            return [];
+        }
 
-		$sharedMods = [];
+        $sharedMods = [];
 
-		foreach ($mods as $key => $mod) {
-			if (!is_string($key)) {
-				continue;
-			}
+        foreach ($mods as $key => $mod) {
+            if (!is_string($key)) {
+                continue;
+            }
 
-			if (in_array($key, self::SETTINGS_EXCLUDED_FROM_EXPORT, true)) {
-				continue;
-			}
+            if (in_array($key, self::SETTINGS_EXCLUDED_FROM_EXPORT, true)) {
+                continue;
+            }
 
-			if (!DesignLibrarySettingPolicy::isAllowedSettingKey($key)) {
-				continue;
-			}
+            if (!DesignLibrarySettingPolicy::isAllowedSettingKey($key)) {
+                continue;
+            }
 
-			$sharedMods[$key] = $mod;
-		}
+            $sharedMods[$key] = $mod;
+        }
 
-		$activeFontFileUrls = $this->getActiveFontFileUrls();
+        $activeFontFileUrls = $this->getActiveFontFileUrls();
 
-		if ($activeFontFileUrls !== []) {
-			$sharedMods['custom_fonts'] = $activeFontFileUrls;
-		}
+        if ($activeFontFileUrls !== []) {
+            $sharedMods['custom_fonts'] = $activeFontFileUrls;
+        }
 
-		return $sharedMods;
-	}
+        return $sharedMods;
+    }
 
-	/**
-	 * Get file URLs for the font families currently activated in the Font Library.
-	 * Fonts present in the Font Library but not activated are intentionally excluded.
-	 *
-	 * @return array<string, string>
-	 */
-	private function getActiveFontFileUrls(): array
-	{
-		$fontFileUrls = [];
+    /**
+     * Get file URLs for the font families currently activated in the Font Library.
+     * Fonts present in the Font Library but not activated are intentionally excluded.
+     *
+     * @return array<string, array<int, array{fontWeight: string, fontStyle: string, src: string}>>
+     */
+    private function getActiveFontFileUrls(): array
+    {
+        $activeFonts = [];
 
-		foreach ($this->getActivatedFontFamilies() as $fontFamily) {
-			$name = $fontFamily['name'] ?? null;
-			$fontFaces = $fontFamily['fontFace'] ?? null;
+        foreach ($this->getActivatedFontFamilies() as $fontFamily) {
+            $name = $fontFamily['name'] ?? null;
+            $fontFaces = $fontFamily['fontFace'] ?? null;
 
-			if (!is_string($name) || $name === '' || !is_array($fontFaces)) {
-				continue;
-			}
+            if (!is_string($name) || $name === '' || !is_array($fontFaces)) {
+                continue;
+            }
 
-			$fontFileUrl = $this->getFirstFontFaceSourceUrl($fontFaces);
+            $fontFaceVariants = $this->getFontFaceVariants($fontFaces);
 
-			if ($fontFileUrl !== null) {
-				$fontFileUrls[$name] = $fontFileUrl;
-			}
-		}
+            if ($fontFaceVariants !== []) {
+                $activeFonts[$name] = $fontFaceVariants;
+            }
+        }
 
-		return $fontFileUrls;
-	}
+        return $activeFonts;
+    }
 
-	/**
-	 * Get the font families currently activated via the Font Library (stored in Global Styles).
-	 *
-	 * @return array<int, array<string, mixed>>
-	 */
-	private function getActivatedFontFamilies(): array
-	{
-		if (
-			!class_exists(\WP_Theme_JSON_Resolver::class)
-			|| !method_exists(\WP_Theme_JSON_Resolver::class, 'get_user_global_styles_post_id')
-		) {
-			return [];
-		}
+    /**
+     * Get the font families currently activated via the Font Library (stored in Global Styles).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function getActivatedFontFamilies(): array
+    {
+        if (!class_exists(\WP_Theme_JSON_Resolver::class) || !method_exists(\WP_Theme_JSON_Resolver::class, 'get_user_global_styles_post_id')) {
+            return [];
+        }
 
-		$globalStylesPostId = \WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+        $globalStylesPostId = \WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
 
-		if (!is_numeric($globalStylesPostId) || (int) $globalStylesPostId <= 0) {
-			return [];
-		}
+        if (!is_numeric($globalStylesPostId) || (int) $globalStylesPostId <= 0) {
+            return [];
+        }
 
-		$globalStylesPost = get_post((int) $globalStylesPostId);
-		$postContent = is_object($globalStylesPost) && property_exists($globalStylesPost, 'post_content')
-			? (string) $globalStylesPost->post_content
-			: '';
+        $globalStylesPost = get_post((int) $globalStylesPostId);
+        $postContent = is_object($globalStylesPost) && property_exists($globalStylesPost, 'post_content') ? (string) $globalStylesPost->post_content : '';
 
-		$globalStylesData = json_decode($postContent, true);
-		$customFontFamilies = $globalStylesData['settings']['typography']['fontFamilies']['custom'] ?? null;
+        $globalStylesData = json_decode($postContent, true);
+        $customFontFamilies = $globalStylesData['settings']['typography']['fontFamilies']['custom'] ?? null;
 
-		return is_array($customFontFamilies) ? array_values(array_filter($customFontFamilies, 'is_array')) : [];
-	}
+        return is_array($customFontFamilies) ? array_values(array_filter($customFontFamilies, 'is_array')) : [];
+    }
 
-	/**
-	 * @param array<int, array<string, mixed>> $fontFaces
-	 */
-	private function getFirstFontFaceSourceUrl(array $fontFaces): ?string
-	{
-		foreach ($fontFaces as $fontFace) {
-			$src = $fontFace['src'] ?? null;
-			$sources = is_array($src) ? $src : (is_string($src) ? [$src] : []);
+    /**
+     * Get every activated weight/style variant for a font family, each with its source URL.
+     *
+     * @param array<int, array<string, mixed>> $fontFaces
+     *
+     * @return array<int, array{fontWeight: string, fontStyle: string, src: string}>
+     */
+    private function getFontFaceVariants(array $fontFaces): array
+    {
+        $variants = [];
 
-			if ($sources !== [] && is_string($sources[0]) && $sources[0] !== '') {
-				return $sources[0];
-			}
-		}
+        foreach ($fontFaces as $fontFace) {
+            $src = $fontFace['src'] ?? null;
+            $sources = is_array($src) ? $src : (is_string($src) ? [$src] : []);
 
-		return null;
-	}
+            if ($sources === [] || !is_string($sources[0]) || $sources[0] === '') {
+                continue;
+            }
+
+            $variants[] = [
+                'fontWeight' => is_string($fontFace['fontWeight'] ?? null) ? $fontFace['fontWeight'] : '400',
+                'fontStyle' => is_string($fontFace['fontStyle'] ?? null) ? $fontFace['fontStyle'] : 'normal',
+                'src' => $sources[0],
+            ];
+        }
+
+        return $variants;
+    }
 }
-

--- a/library/Api/Customizer/DesignLibrary.php
+++ b/library/Api/Customizer/DesignLibrary.php
@@ -4,7 +4,6 @@ namespace Municipio\Api\Customizer;
 
 use Municipio\Api\RestApiEndpoint;
 use Municipio\Customizer\DesignLibrarySettingPolicy;
-use Municipio\Helper\WpService as WpServiceHelper;
 use WP_Error;
 use WP_Http;
 use WP_REST_Response;
@@ -220,60 +219,91 @@ class DesignLibrary extends RestApiEndpoint
 			}
 
 			$sharedMods[$key] = $mod;
+		}
 
-			if (!empty($mod['font-family']) && is_string($mod['font-family'])) {
-				$fontFileUrl = $this->getUploadedFontUrl($mod['font-family']);
-				if ($fontFileUrl !== null) {
-					$sharedMods['custom_fonts'][$mod['font-family']] = $fontFileUrl;
-				}
-			}
+		$activeFontFileUrls = $this->getActiveFontFileUrls();
+
+		if ($activeFontFileUrls !== []) {
+			$sharedMods['custom_fonts'] = $activeFontFileUrls;
 		}
 
 		return $sharedMods;
 	}
 
-	private function getUploadedFontUrl(string $fontFamily = ''): ?string
+	/**
+	 * Get file URLs for the font families currently activated in the Font Library.
+	 * Fonts present in the Font Library but not activated are intentionally excluded.
+	 *
+	 * @return array<string, string>
+	 */
+	private function getActiveFontFileUrls(): array
 	{
-		if ($fontFamily === '') {
-			return null;
-		}
+		$fontFileUrls = [];
 
-		$wpService = WpServiceHelper::get();
+		foreach ($this->getActivatedFontFamilies() as $fontFamily) {
+			$name = $fontFamily['name'] ?? null;
+			$fontFaces = $fontFamily['fontFace'] ?? null;
 
-		if (!$wpService->postTypeExists('wp_font_family') || !$wpService->postTypeExists('wp_font_face')) {
-			return null;
-		}
-
-		$fontFamilyPost = $wpService->getPageByPath($wpService->sanitizeTitle($fontFamily), 'OBJECT', 'wp_font_family');
-
-		if (!is_object($fontFamilyPost) || !property_exists($fontFamilyPost, 'ID')) {
-			return null;
-		}
-
-		$fontFaces = $wpService->getPosts([
-			'post_type' => 'wp_font_face',
-			'post_status' => 'publish',
-			'post_parent' => (int) $fontFamilyPost->ID,
-			'posts_per_page' => -1,
-			'update_post_meta_cache' => false,
-			'update_post_term_cache' => false,
-		]);
-
-		foreach ($fontFaces as $fontFace) {
-			$fontFaceSettings = is_object($fontFace) && property_exists($fontFace, 'post_content')
-				? json_decode((string) $fontFace->post_content, true)
-				: null;
-			$sources = is_array($fontFaceSettings) && isset($fontFaceSettings['src'])
-				? (array) $fontFaceSettings['src']
-				: [];
-
-			if ($sources === [] || !is_string($sources[0]) || $sources[0] === '') {
+			if (!is_string($name) || $name === '' || !is_array($fontFaces)) {
 				continue;
 			}
 
-			return $sources[0];
+			$fontFileUrl = $this->getFirstFontFaceSourceUrl($fontFaces);
+
+			if ($fontFileUrl !== null) {
+				$fontFileUrls[$name] = $fontFileUrl;
+			}
+		}
+
+		return $fontFileUrls;
+	}
+
+	/**
+	 * Get the font families currently activated via the Font Library (stored in Global Styles).
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function getActivatedFontFamilies(): array
+	{
+		if (
+			!class_exists(\WP_Theme_JSON_Resolver::class)
+			|| !method_exists(\WP_Theme_JSON_Resolver::class, 'get_user_global_styles_post_id')
+		) {
+			return [];
+		}
+
+		$globalStylesPostId = \WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+
+		if (!is_numeric($globalStylesPostId) || (int) $globalStylesPostId <= 0) {
+			return [];
+		}
+
+		$globalStylesPost = get_post((int) $globalStylesPostId);
+		$postContent = is_object($globalStylesPost) && property_exists($globalStylesPost, 'post_content')
+			? (string) $globalStylesPost->post_content
+			: '';
+
+		$globalStylesData = json_decode($postContent, true);
+		$customFontFamilies = $globalStylesData['settings']['typography']['fontFamilies']['custom'] ?? null;
+
+		return is_array($customFontFamilies) ? array_values(array_filter($customFontFamilies, 'is_array')) : [];
+	}
+
+	/**
+	 * @param array<int, array<string, mixed>> $fontFaces
+	 */
+	private function getFirstFontFaceSourceUrl(array $fontFaces): ?string
+	{
+		foreach ($fontFaces as $fontFace) {
+			$src = $fontFace['src'] ?? null;
+			$sources = is_array($src) ? $src : (is_string($src) ? [$src] : []);
+
+			if ($sources !== [] && is_string($sources[0]) && $sources[0] !== '') {
+				return $sources[0];
+			}
 		}
 
 		return null;
 	}
 }
+

--- a/library/Api/Customizer/DesignLibraryFontActivation.php
+++ b/library/Api/Customizer/DesignLibraryFontActivation.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Municipio\Api\Customizer;
+
+use Municipio\Api\RestApiEndpoint;
+use Municipio\Helper\WpService as WpServiceHelper;
+use Municipio\Upgrade\V42\InteractsWithNativeFontLibrary;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use WpService\WpService;
+
+/**
+ * Downloads a font-face variant from a Design Library import and activates it in the native Font Library.
+ */
+class DesignLibraryFontActivation extends RestApiEndpoint
+{
+    use InteractsWithNativeFontLibrary;
+
+    private const NAMESPACE = 'municipio/v1';
+    private const ROUTE = 'design-library/activate-font';
+
+    public function handleRegisterRestRoute(): bool
+    {
+        return register_rest_route(self::NAMESPACE, self::ROUTE, [
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => [$this, 'handleRequest'],
+            'permission_callback' => [$this, 'permissionCallback'],
+            'args' => [
+                'fontFamily' => [
+                    'description' => __('Font family name to activate.', 'municipio'),
+                    'type' => 'string',
+                    'required' => true,
+                ],
+                'fontWeight' => [
+                    'description' => __('Font weight of the face to activate.', 'municipio'),
+                    'type' => 'string',
+                    'required' => false,
+                    'default' => '400',
+                ],
+                'fontStyle' => [
+                    'description' => __('Font style of the face to activate.', 'municipio'),
+                    'type' => 'string',
+                    'required' => false,
+                    'default' => 'normal',
+                ],
+                'url' => [
+                    'description' => __('Remote URL of the font file to download and activate.', 'municipio'),
+                    'type' => 'string',
+                    'format' => 'uri',
+                    'required' => true,
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Restrict font activation to authenticated users with Customizer capability.
+     */
+    public function permissionCallback(): bool
+    {
+        return is_user_logged_in() && current_user_can('customize');
+    }
+
+    /**
+     * @return WP_REST_Response|WP_Error
+     */
+    public function handleRequest(WP_REST_Request $request)
+    {
+        $fontFamily = (string) $request->get_param('fontFamily');
+        $fontWeight = (string) $request->get_param('fontWeight');
+        $fontStyle = (string) $request->get_param('fontStyle');
+        $url = (string) $request->get_param('url');
+
+        if (trim($fontFamily) === '' || trim($url) === '') {
+            return new WP_Error(
+                'municipio_font_activation_missing_params',
+                __('Missing font family or file URL.', 'municipio'),
+                ['status' => WP_Http::BAD_REQUEST],
+            );
+        }
+
+        if (!$this->nativeFontLibraryIsAvailable()) {
+            return new WP_Error(
+                'municipio_font_activation_unavailable',
+                __('The native font library is not available on this site.', 'municipio'),
+                ['status' => WP_Http::NOT_IMPLEMENTED],
+            );
+        }
+
+        $fontFamilyPostId = $this->createNativeFontFamilyIfMissing($fontFamily);
+
+        if ($fontFamilyPostId === null) {
+            return new WP_Error(
+                'municipio_font_activation_family_failed',
+                __('Unable to create or find the font family.', 'municipio'),
+                ['status' => WP_Http::INTERNAL_SERVER_ERROR],
+            );
+        }
+
+        $downloadedFontFile = $this->downloadFontFile($url);
+
+        if ($downloadedFontFile === null) {
+            return new WP_Error(
+                'municipio_font_activation_download_failed',
+                __('Unable to download the font file.', 'municipio'),
+                ['status' => WP_Http::BAD_GATEWAY],
+            );
+        }
+
+        $this->createNativeFontFaceIfMissing(
+            $fontFamilyPostId,
+            $fontFamily,
+            $downloadedFontFile['url'],
+            $fontStyle !== '' ? $fontStyle : 'normal',
+            $fontWeight !== '' ? $fontWeight : '400',
+            $downloadedFontFile['fontFile'],
+        );
+
+        return rest_ensure_response([
+            'success' => true,
+            'fontFamilyId' => $fontFamilyPostId,
+        ]);
+    }
+
+    /**
+     * Downloads a remote font file into WordPress' native font uploads directory.
+     *
+     * @return array{url: string, fontFile: string}|null
+     */
+    private function downloadFontFile(string $url): ?array
+    {
+        $this->ensureDownloadUrlIsAvailable();
+
+        $wpService = $this->getWpService();
+        $temporaryFile = $wpService->downloadUrl($url);
+
+        if ($wpService->isWpError($temporaryFile) || !is_string($temporaryFile) || $temporaryFile === '') {
+            return null;
+        }
+
+        $file = [
+            'name' => $this->getDownloadedFontFileName($url, $temporaryFile),
+            'tmp_name' => $temporaryFile,
+            'error' => 0,
+            'size' => (int) filesize($temporaryFile),
+        ];
+
+        $overrides = ['test_form' => false];
+
+        if (class_exists(\WP_Font_Utils::class) && method_exists(\WP_Font_Utils::class, 'get_allowed_font_mime_types')) {
+            $overrides['mimes'] = \WP_Font_Utils::get_allowed_font_mime_types();
+        }
+
+        $wpService->addFilter('upload_dir', '_wp_filter_font_directory');
+        $sideloadedFile = $wpService->wpHandleSideload($file, $overrides);
+        $wpService->removeFilter('upload_dir', '_wp_filter_font_directory');
+
+        if (!is_array($sideloadedFile) || empty($sideloadedFile['file']) || empty($sideloadedFile['url'])) {
+            if (file_exists($temporaryFile)) {
+                unlink($temporaryFile);
+            }
+
+            return null;
+        }
+
+        return [
+            'url' => (string) $sideloadedFile['url'],
+            'fontFile' => $this->relativeFontsPath((string) $sideloadedFile['file']),
+        ];
+    }
+
+    private function getDownloadedFontFileName(string $source, string $temporaryFile): string
+    {
+        $path = (string) parse_url($source, PHP_URL_PATH);
+        $fileName = basename($path);
+
+        if ($fileName !== '' && $fileName !== '/' && $fileName !== '.') {
+            return $fileName;
+        }
+
+        $extension = pathinfo($temporaryFile, PATHINFO_EXTENSION);
+
+        return $extension !== '' ? 'font.' . $extension : 'font-file';
+    }
+
+    private function relativeFontsPath(string $path): string
+    {
+        $fontDir = $this->getWpService()->wpGetFontDir();
+        $baseDir = isset($fontDir['basedir']) && is_string($fontDir['basedir']) ? rtrim($fontDir['basedir'], '/') : '';
+
+        if ($baseDir !== '' && str_starts_with($path, $baseDir)) {
+            return ltrim(substr($path, strlen($baseDir)), '/');
+        }
+
+        return $path;
+    }
+
+    private function ensureDownloadUrlIsAvailable(): void
+    {
+        if (function_exists('download_url') || !defined('ABSPATH')) {
+            return;
+        }
+
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+    }
+
+    protected function getWpService(): WpService
+    {
+        return WpServiceHelper::get();
+    }
+}

--- a/library/Api/Customizer/DesignLibraryFontActivationTest.php
+++ b/library/Api/Customizer/DesignLibraryFontActivationTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Municipio\Api\Customizer;
+
+use PHPUnit\Framework\TestCase;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WpService\Implementations\FakeWpService;
+use WpService\WpService;
+
+if (!function_exists(__NAMESPACE__ . '\\is_user_logged_in')) {
+    /**
+     * Test double for is_user_logged_in.
+     */
+    function is_user_logged_in(): bool
+    {
+        return DesignLibraryFontActivationTestState::$isUserLoggedIn;
+    }
+}
+
+if (!function_exists(__NAMESPACE__ . '\\current_user_can')) {
+    /**
+     * Test double for current_user_can.
+     */
+    function current_user_can(string $capability): bool
+    {
+        return DesignLibraryFontActivationTestState::$currentUserCan;
+    }
+}
+
+if (!function_exists(__NAMESPACE__ . '\\rest_ensure_response')) {
+    /**
+     * Test double for the REST response helper.
+     *
+     * @param mixed $response The response payload.
+     *
+     * @return WP_REST_Response
+     */
+    function rest_ensure_response($response)
+    {
+        return new class($response) extends WP_REST_Response {
+            /**
+             * @param mixed $data The response payload.
+             */
+            public function __construct($data = null)
+            {
+                $this->data = $data;
+                $this->status = 200;
+                $this->headers = [];
+            }
+
+            /**
+             * @return array<string, mixed>
+             */
+            public function get_headers()
+            {
+                return $this->headers;
+            }
+
+            /**
+             * @param string $key The header name.
+             * @param mixed $value The header value.
+             * @param bool $replace Whether to replace an existing header.
+             */
+            public function header($key, $value, $replace = true)
+            {
+                $existingHeader = $this->headers[$key] ?? null;
+
+                if ($replace || $existingHeader === null) {
+                    $this->headers[$key] = $value;
+                    return;
+                }
+
+                $this->headers[$key] = array_merge((array) $existingHeader, [$value]);
+            }
+        };
+    }
+}
+
+/**
+ * Mutable state backing the is_user_logged_in()/current_user_can() test doubles above.
+ */
+class DesignLibraryFontActivationTestState
+{
+    public static bool $isUserLoggedIn = true;
+    public static bool $currentUserCan = true;
+}
+
+class DesignLibraryFontActivationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        DesignLibraryFontActivationTestState::$isUserLoggedIn = true;
+        DesignLibraryFontActivationTestState::$currentUserCan = true;
+    }
+
+    public function testPermissionCallbackRequiresLoggedInUserWithCustomizeCapability(): void
+    {
+        $endpoint = new DesignLibraryFontActivation();
+
+        DesignLibraryFontActivationTestState::$isUserLoggedIn = false;
+        $this->assertFalse($endpoint->permissionCallback());
+
+        DesignLibraryFontActivationTestState::$isUserLoggedIn = true;
+        DesignLibraryFontActivationTestState::$currentUserCan = false;
+        $this->assertFalse($endpoint->permissionCallback());
+
+        DesignLibraryFontActivationTestState::$currentUserCan = true;
+        $this->assertTrue($endpoint->permissionCallback());
+    }
+
+    public function testHandleRequestDownloadsAndActivatesTheFontFace(): void
+    {
+        $wpService = new FakeWpService([
+            'postTypeExists' => static fn(string $postType): bool => in_array($postType, ['wp_font_family', 'wp_font_face'], true),
+            'sanitizeTitle' => static fn(string $title): string => strtolower(str_replace(' ', '-', $title)),
+            'wpJsonEncode' => static fn(mixed $value): string|false => json_encode($value),
+            'wpSlash' => static fn(string|array $value): string|array => is_string($value) ? addslashes($value) : $value,
+            'isWpError' => false,
+            'getPageByPath' => null,
+            'downloadUrl' => static fn(string $url): string => '/tmp/roboto-700.woff2',
+            'addFilter' => true,
+            'removeFilter' => true,
+            'wpHandleSideload' => static fn(array $file): array => [
+                'file' => '/var/www/wp-content/uploads/fonts/roboto-700.woff2',
+                'url' => 'https://example.com/wp-content/uploads/fonts/roboto-700.woff2',
+                'type' => 'font/woff2',
+            ],
+            'wpGetFontDir' => [
+                'basedir' => '/var/www/wp-content/uploads/fonts',
+                'baseurl' => 'https://example.com/wp-content/uploads/fonts',
+            ],
+            'getPosts' => [],
+            'wpInsertPost' => static fn(array $postarr): int => $postarr['post_type'] === 'wp_font_family' ? 41 : 42,
+            'addPostMeta' => true,
+        ]);
+
+        $endpoint = new class($wpService) extends DesignLibraryFontActivation {
+            public function __construct(
+                private WpService $wpService,
+            ) {}
+
+            protected function getWpService(): WpService
+            {
+                return $this->wpService;
+            }
+        };
+
+        $request = $this->createMock(WP_REST_Request::class);
+        $request
+            ->method('get_param')
+            ->willReturnMap([
+                ['fontFamily', 'Roboto'],
+                ['fontWeight', '700'],
+                ['fontStyle',  'normal'],
+                ['url',        'https://fonts.example.com/roboto-700.woff2'],
+            ]);
+
+        $response = $endpoint->handleRequest($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertSame(['success' => true, 'fontFamilyId' => 41], $response->data);
+        $this->assertSame(
+            ['wp_font_family', 'wp_font_face'],
+            array_values(array_map(
+                static fn(array $call): string => $call[0]['post_type'],
+                $wpService->methodCalls['wpInsertPost'],
+            )),
+        );
+        $this->assertSame(
+            [[42, '_wp_font_face_file', 'roboto-700.woff2']],
+            $wpService->methodCalls['addPostMeta'],
+        );
+    }
+
+    public function testHandleRequestReturnsErrorWhenMissingParams(): void
+    {
+        $endpoint = new DesignLibraryFontActivation();
+
+        $request = $this->createMock(WP_REST_Request::class);
+        $request
+            ->method('get_param')
+            ->willReturnMap([
+                ['fontFamily', ''],
+                ['fontWeight', '400'],
+                ['fontStyle',  'normal'],
+                ['url',        ''],
+            ]);
+
+        $response = $endpoint->handleRequest($request);
+
+        $this->assertInstanceOf(WP_Error::class, $response);
+    }
+}

--- a/library/Api/Customizer/DesignLibraryTest.php
+++ b/library/Api/Customizer/DesignLibraryTest.php
@@ -18,7 +18,7 @@ if (!function_exists(__NAMESPACE__ . '\\rest_ensure_response')) {
      */
     function rest_ensure_response($response)
     {
-        return new class ($response) extends WP_REST_Response {
+        return new class($response) extends WP_REST_Response {
             /**
              * @param mixed $data The response payload.
              */
@@ -74,10 +74,10 @@ class DesignLibraryTest extends TestCase
             'css' => '.site-header { color: #000; }',
         ];
 
-        $endpoint = new class ($expectedPayload) extends DesignLibrary {
-            public function __construct(private array $payload)
-            {
-            }
+        $endpoint = new class($expectedPayload) extends DesignLibrary {
+            public function __construct(
+                private array $payload,
+            ) {}
 
             protected function getSiteConfig(): array
             {

--- a/library/App.php
+++ b/library/App.php
@@ -155,7 +155,7 @@ class App
             $this->wpService,
             $this->acfService,
             $this->wpUtilService->enqueue(),
-            new AdminNotices($this->wpService)
+            new AdminNotices($this->wpService),
         ))->enable();
 
         /**
@@ -257,6 +257,7 @@ class App
         RestApiEndpointsRegistry::add(new \Municipio\Api\PlaceSearch\PlaceSearchEndpoint($this->wpService));
         RestApiEndpointsRegistry::add(new \Municipio\Api\Nonce\Refresh());
         RestApiEndpointsRegistry::add(new \Municipio\Api\Customizer\DesignLibrary());
+        RestApiEndpointsRegistry::add(new \Municipio\Api\Customizer\DesignLibraryFontActivation());
 
         $pdfHelper = new \Municipio\Api\Pdf\PdfHelper();
         $pdfGenerator = new \Municipio\Api\Pdf\PdfGenerator($pdfHelper);

--- a/library/Theme/Enqueue.php
+++ b/library/Theme/Enqueue.php
@@ -126,7 +126,7 @@ class Enqueue implements Hookable
     public function enqueueCustomizerScriptsAndStyles()
     {
         $this->enqueue
-            ->add('js/design-share.js', ['jquery', 'customize-controls'])
+            ->add('js/design-share.js', ['jquery', 'customize-controls', 'wp-api-request'])
             ->with()
             ->translation('municipioDesignShareConfig', [
                 'minimumSupportedDbVersion' => (int) get_option('municipio_db_version', 0),


### PR DESCRIPTION
This pull request implements support for importing and activating custom fonts (with all their variants) when importing a design from the Design Library. It introduces a new REST API endpoint for activating fonts, updates the frontend logic to handle font variants, and refactors how font data is exported and imported. This ensures that all font weights and styles are correctly transferred and activated during a design import.

**Font Import/Export and Activation Improvements**

* Added a new backend REST API endpoint (`DesignLibraryFontActivation`) to download and activate font-face variants in the native Font Library during design import. This endpoint handles font file downloads, creates font families and faces if missing, and ensures proper permissions.
* Refactored the export logic in `DesignLibrary.php` to include all activated font variants (weight, style, and source URL) for each custom font family, instead of just a single font file.

**Frontend Integration**

* Updated the frontend (`designShareUtils.ts`) to:
  * Import and activate all custom font variants using the new `activateFont` endpoint during design import, instead of just sideloading a single font file. [[1]](diffhunk://#diff-df9383f9e8404be5dd3faa478c007ea33388df34b6064631f8ac8c5dc4dd205bL303-R340) [[2]](diffhunk://#diff-df9383f9e8404be5dd3faa478c007ea33388df34b6064631f8ac8c5dc4dd205bR1)
  * Add type guards and structures for font variants to ensure type safety and correct processing.
  * Pass authentication nonce header when fetching remote design data.

**API Endpoint**

* Added `activateFont` endpoint definition for frontend use, specifying required arguments and response structure.

These changes ensure that all custom fonts, including their variants, are reliably imported and activated with the correct settings when a design is shared or imported.