### PR TITLE
fix: deprecate remove script versions and meta generator

### DIFF
--- a/library/Theme/Enqueue.php
+++ b/library/Theme/Enqueue.php
@@ -43,9 +43,6 @@ class Enqueue implements Hookable
             [$this, 'enqueueCustomizerPreviewScripts'],
             999,
         );
-        $this->wpService->addFilter('script_loader_src', [$this, 'removeScriptVersion'], 15, 1);
-        $this->wpService->addFilter('style_loader_src', [$this, 'removeScriptVersion'], 15, 1);
-        $this->wpService->addFilter('the_generator', [$this, 'removeGeneratorTag'], 9, 2);
         $this->wpService->addAction('wp_default_scripts', [$this, 'removeJqueryMigrate']);
         $this->wpService->addFilter('gform_init_scripts_footer', [$this, 'forceGravityFormsScriptsNotInFooter']);
     }
@@ -144,22 +141,6 @@ class Enqueue implements Hookable
     public function enqueueCustomizerPreviewScripts(): void
     {
         $this->enqueue->add('js/customizer-header-logo-scroll-aspect-ratio-preview.js', ['customize-preview']);
-    }
-
-    /**
-     * Removes querystring from any scripts/styles internally
-     *
-     * @param string $src The soruce path
-     *
-     * @return string      The source path without any querystring
-     */
-    public function removeScriptVersion($src): string
-    {
-        $urlComponents = parse_url($src);
-        if (!empty($urlComponents['query'])) {
-            $src = str_replace('?' . $urlComponents['query'], '', $src);
-        }
-        return $src;
     }
 
     /**


### PR DESCRIPTION
This pull request removes some code related to filtering script and style URLs and the generator tag in the WordPress theme enqueue logic. The main focus is on cleaning up unused or unnecessary filters and their associated methods.

**Removed filters and related methods:**

* Stopped adding filters to remove query strings from script and style URLs by removing the `removeScriptVersion` filter hooks from `addHooks()` in `Enqueue.php`.
* Deleted the `removeScriptVersion` method, which stripped query strings from script and style URLs.

These changes help simplify the enqueue logic by removing customizations that may no longer be needed.