### PR TITLE
Update helsingborg-stad/wputilservice to ^0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "league/config": "v1.2.0",
     "freshleafmedia/autofocus": "^1.0",
     "astrotomic/php-deepface": "0.5.0",
-    "helsingborg-stad/wputilservice": "0.3.0",
+    "helsingborg-stad/wputilservice": "^0.3",
     "helsingborg-stad/styleguide": "3.19.10",
     "firebase/php-jwt": "v7.1.0",
     "algolia/algoliasearch-client-php": "4.47.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e2d2054d29a64c853fd6584ce9b9983c",
+    "content-hash": "94662f93e9b5a9603dc9474a91be188d",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",


### PR DESCRIPTION
## Summary

Updates the `helsingborg-stad/wputilservice` dependency constraint to `^0.3`.

## Changes

- Updated the existing `helsingborg-stad/wputilservice` dependency constraint to `^0.3`
- Updated `composer.lock` where applicable
- Ran `composer update helsingborg-stad/wputilservice --with-all-dependencies`
- Ran `composer install`
- Ran `composer validate`

This change removes this package as a blocker for upgrading `helsingborg-stad/wputilservice` to `^0.3`.